### PR TITLE
Add Open Knowledge Format (OKF) bundle

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -8,6 +8,10 @@
 - [Values](https://middleton.io/#values): Operating principles — start with understanding, give grace get grace, collaboration wins, keep it human, structure without rigidity, make it simple.
 - [What he's looking for](https://middleton.io/#looking-for): Product management, internal tools, platforms, public sector, AI workflows, integrations.
 
+## Knowledge bundle (OKF)
+
+- [Open Knowledge Format bundle](https://middleton.io/okf/index.md): A machine-readable OKF bundle of Kevin's profile, systems, methods, and work as cross-linked Markdown concepts, built for AI agents. Start at /okf/index.md.
+
 ## Blog
 
 <!-- BLOG:START -->

--- a/okf/building-with-ai.md
+++ b/okf/building-with-ai.md
@@ -1,0 +1,28 @@
+---
+type: Methodology
+title: Building With AI
+description: How Kevin Middleton, a product manager rather than an engineer, ships real working software with AI. Own the goal and the verification, let AI handle implementation, and work inside a system that improves over time.
+resource: https://middleton.io/blog/everyone-can-build-now/
+tags: [building-with-ai, product-management, methodology]
+timestamp: 2026-06-30
+---
+
+# Building With AI
+
+The thesis: the bottleneck in building software was never knowing how to build. It was knowing what to build and being able to tell when it's right. AI collapses the implementation cost, so a product manager who can specify a goal precisely and verify an output rigorously can ship the thing, not just write the ticket for it.
+
+## How Kevin actually works with AI
+
+**Own the goal, not the syntax.** The job is to get the real goal out of your head and into a form the AI can act on. A task is "build a report." The goal is the decision the report drives. AI can do the task once it has the goal, and it can never decide the goal for you.
+
+**Work in small, verifiable loops.** Don't hand the AI the whole thing and wait for a finished product. Scope tightly, check the output, adjust, repeat.
+
+**Verify like it's the job, because it is.** AI is reliable where there is a clear answer and confidently wrong where there isn't. The lever that improves results is verification: define what good looks like up front, pull in external signal, and use a second pass to critique the first.
+
+**Make the environment permanent.** A good setup compounds. Persistent context, reusable skills, and durable rules beat starting from scratch every session. That environment is his [Personal OS](personal-os.md).
+
+## The proof
+
+His own systems are the evidence: an automated job search, a self-deploying blog pipeline, and a voice system that keeps AI writing in his own voice. All of it built and operated by a PM, not an engineering team. See [Personal OS](personal-os.md) for the builds and [owning your context](owning-your-context.md) for the belief underneath.
+
+Related reading: [Everyone can build now. The fundamentals shouldn't change.](https://middleton.io/blog/everyone-can-build-now/)

--- a/okf/case-studies.md
+++ b/okf/case-studies.md
@@ -1,0 +1,36 @@
+---
+type: CaseStudy
+title: Selected Case Studies
+description: Representative product work by Kevin Middleton across HVAC.com, Sendoso, Lever, Rocket Lawyer, and Oracle.
+resource: https://middleton.io/casestudies/
+tags: [case-studies, work-history, product-management]
+timestamp: 2026-06-30
+---
+
+# Selected Case Studies
+
+Full write-ups at https://middleton.io/casestudies/
+
+## HVAC.com: Calculators and Conversion Optimization
+Drove a large conversion lift through high-intent tools and continuous A/B testing.
+https://middleton.io/casestudies/case-study-hvac.html
+
+## Sendoso: eGift Platform Expansion and Square Partnership
+Doubled eGift coverage to 1,600+ options across 47 countries and landed Square as a strategic partner.
+https://middleton.io/casestudies/case-study-sendoso.html
+
+## Lever: Moving Upmarket
+Built HRIS Sync from zero and reduced migration time from days to minutes.
+https://middleton.io/casestudies/case-study-lever.html
+
+## Rocket Lawyer: Co-Branded Partner Sites (Covea)
+Launched Rocket Lawyer's first enterprise partnership in six months, reaching millions of users.
+https://middleton.io/casestudies/case-study-rocketlawyer-covea.html
+
+## Rocket Lawyer: Mobile Conversion Optimization
+Mobile conversion lift on the highest-revenue product line.
+https://middleton.io/casestudies/case-study-rocketlawyer-mobile.html
+
+## Oracle: Engage v2 and New Networks
+Shipped 36 new features in 12 months and doubled social network coverage.
+https://middleton.io/casestudies/case-study-oracle.html

--- a/okf/contact.md
+++ b/okf/contact.md
@@ -1,0 +1,19 @@
+---
+type: Contact
+title: Contact Kevin Middleton
+description: How to reach Kevin Middleton.
+resource: https://middleton.io
+tags: [contact, scheduling]
+timestamp: 2026-06-30
+---
+
+# Contact
+
+- Website: https://middleton.io
+- Email: kevin@middleton.io
+- LinkedIn: https://www.linkedin.com/in/kevinmiddleton
+- GitHub: https://github.com/kevinmmiddleton
+- Wikidata: https://www.wikidata.org/wiki/Q140389537
+- Book a free intro chat: https://calendly.com/kevin-middleton/let-s-talk
+
+Kevin offers a free introductory consultation to discuss product strategy, team processes, or career advice, and runs free 30-minute Office Hours at https://middleton.io/officehours/.

--- a/okf/how-i-work.md
+++ b/okf/how-i-work.md
@@ -1,0 +1,26 @@
+---
+type: Document
+title: How Kevin Works
+description: Kevin Middleton's working style and approach to collaboration.
+resource: https://middleton.io
+tags: [working-style, collaboration, values]
+timestamp: 2026-06-30
+---
+
+# How Kevin Works
+
+## Quietly effective
+
+Shows up prepared, keeps things organized, and follows through without making a big deal out of it. A former manager put it simply: "He just shows up and knows his job and the value his products will bring."
+
+## Bridge builder
+
+Connects the teams that don't usually talk to each other: engineering and support, product and marketing. A colleague called him "the personification of integration between people, process, and technology."
+
+## Quality-first
+
+Fights for good work. Not gold-plating, but getting the details right, the edge cases covered, and the experience polished. Colleagues describe him as "a top-notch PM who will fight for quality products as well as for his team."
+
+## Fun to work with
+
+Brings energy and humor that helps teams do their best work. Colleagues across companies echo it: "He made it fun in the process." "Our projects were always made fun."

--- a/okf/index.md
+++ b/okf/index.md
@@ -1,0 +1,27 @@
+---
+type: Collection
+title: "Kevin Middleton: Open Knowledge Bundle"
+description: Machine-readable knowledge about Kevin Middleton, a Senior / Full Stack Product Manager in New York who builds working software with AI.
+resource: https://middleton.io
+tags: [profile, product-management, building-with-ai, index]
+timestamp: 2026-06-30
+---
+
+# Kevin Middleton: Open Knowledge Bundle
+
+This is an [Open Knowledge Format (OKF)](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing) bundle: a directory of Markdown files, each describing one concept, written for AI agents and other automated readers.
+
+Source of truth for this content is the website at https://middleton.io. Files in this bundle:
+
+- [`profile.md`](profile.md): who Kevin is, role, location, links
+- [`how-i-work.md`](how-i-work.md): working style and collaboration approach
+- [`building-with-ai.md`](building-with-ai.md): how a non-engineer PM ships real software with AI
+- [`personal-os.md`](personal-os.md): the self-hosted systems he built and runs
+- [`owning-your-context.md`](owning-your-context.md): his data-ownership philosophy
+- [`skills.md`](skills.md): areas of expertise
+- [`case-studies.md`](case-studies.md): selected work and outcomes
+- [`projects.md`](projects.md): personal and side projects
+- [`writing.md`](writing.md): essays and where to find them
+- [`contact.md`](contact.md): how to reach Kevin
+
+Last reviewed: 2026-06-30. OKF spec version targeted: v0.1.

--- a/okf/owning-your-context.md
+++ b/okf/owning-your-context.md
@@ -1,0 +1,26 @@
+---
+type: Philosophy
+title: Owning Your Context
+description: Kevin Middleton's belief that your data and the infrastructure around it are your real advantage. Keep your context yourself and bring it to whichever model is best, rather than renting your second mind from a product that can change the terms.
+resource: https://middleton.io/blog/owning-your-context/
+tags: [data-ownership, privacy, infrastructure, philosophy]
+timestamp: 2026-06-30
+---
+
+# Owning Your Context
+
+The principle underneath everything Kevin builds: the value is not the model, it is the context you feed it, and you should own that context.
+
+## The idea
+
+AI is only as useful as the context it has. If your context lives inside a product you don't control, your leverage lives there too, subject to someone else's pricing, retention, and terms. The durable position is to keep the context yourself and bring it to whichever model is best at the moment. Models are swappable. The brain should not be.
+
+This is why his [Personal OS](personal-os.md) is self-hosted: a database he owns, skills in his own repo, automations on his own hardware. The AI is a tenant in his world, not the other way around.
+
+## Where it came from
+
+Kevin wrote about paying to scrub his data from hundreds of brokers, then deliberately handing far more of it to an AI he controls, and why those are not contradictory. The distinction is control, not exposure. Read [I Paid to Scrub My Data From Hundreds of Data Brokers. Then I Sent Even More to an AI.](https://middleton.io/blog/owning-your-context/)
+
+## Why this bundle exists
+
+This OKF bundle is the same philosophy applied to a public presence. Instead of letting agents scrape and guess, Kevin publishes a clean, curated, owned representation of his own knowledge. He decides what is in his context. See [how he builds with AI](building-with-ai.md).

--- a/okf/personal-os.md
+++ b/okf/personal-os.md
@@ -1,0 +1,32 @@
+---
+type: System
+title: Personal OS
+description: Kevin Middleton's self-hosted personal operating system. A shared database brain plus version-controlled skills that his AI agents read and write across multiple machines, running his job search, his blog, and more.
+resource: https://middleton.io/blog/ai-job-search-assistant/
+tags: [personal-os, automation, building-with-ai, infrastructure]
+timestamp: 2026-06-30
+---
+
+# Personal OS
+
+Personal OS is the infrastructure under everything Kevin builds with AI. The idea: give AI a persistent brain and a stable set of skills so it stops starting from scratch every conversation and instead compounds.
+
+## The shape
+
+**One shared brain.** Structured data lives in a self-hosted Postgres database any AI instance can query. Job applications, the project board, daily briefings, and content live as tables. The database is the source of truth, not files that drift.
+
+**Skills as the interface.** Repeatable work is captured as skills, version-controlled in a private repo and synced to each machine, so a fix in one place reaches every place.
+
+**Multiple machines, one state.** A laptop and an always-on Mac Mini both read and write the same brain. The Mac Mini runs scheduled automations while Kevin sleeps.
+
+## What it runs
+
+**An automated job search.** Twice a day the Mac Mini scans for product-manager roles, classifies each one with a small language model, and texts Kevin the matches for about six cents a day. Every application is tracked in the database, more than 1,200 and counting. Written up in [I Built an AI Job Search Assistant That Texts Me](https://middleton.io/blog/ai-job-search-assistant/).
+
+**A self-deploying blog.** A post is one database row. Flipping its status to published triggers a build that renders static HTML and deploys the site, so content is baked in for search and AI crawlers.
+
+**A voice system.** A documented voice guide, an anti-AI-tell checklist, and a validation script keep AI-assisted writing sounding like Kevin instead of like a model.
+
+## Why it matters
+
+Most people use AI as a blank workshop every time. Personal OS makes the workshop permanent, so the environment improves and corrections become durable. It is the environment layer of [how Kevin builds with AI](building-with-ai.md), and the practical form of [owning your context](owning-your-context.md). Some of the tools have been open-sourced; see [projects](projects.md).

--- a/okf/profile.md
+++ b/okf/profile.md
@@ -1,0 +1,32 @@
+---
+type: Profile
+title: Kevin Middleton
+description: Senior Product Manager and Full Stack PM with 12+ years building platforms, internal tools, and AI-driven workflows for enterprise and consumer SaaS products. Ships working software with AI without being an engineer.
+resource: https://middleton.io
+tags: [profile, product-manager, building-with-ai, new-york]
+timestamp: 2026-06-30
+---
+
+# Kevin Middleton
+
+**Role:** Senior Product Manager / Full Stack Product Manager
+**Location:** New York, NY, USA
+**Education:** Virginia Tech
+
+## Summary
+
+Kevin Middleton is a hands-on product leader with 12+ years building platforms, internal tools, and AI-driven workflows across enterprise and consumer SaaS. He works across people, process, and product: running meetings, digging into data, building prototypes, and turning complex problems into maintainable systems teams can own.
+
+## Builds with AI
+
+What makes him unusual is that he ships real, working software without writing code by hand. He treats AI as the implementation layer and keeps the parts only a person can do: knowing what to build, and knowing when it's right. The proof is his own infrastructure. He runs a self-hosted [Personal OS](personal-os.md) that automates his job search, publishes his blog, and keeps AI writing in his voice. For how he does it, see [building with AI](building-with-ai.md). For the belief underneath it, see [owning your context](owning-your-context.md).
+
+## Links
+
+- Website: https://middleton.io
+- LinkedIn: https://www.linkedin.com/in/kevinmiddleton
+- GitHub: https://github.com/kevinmmiddleton
+
+## Knows about
+
+Product Management, SaaS, Product Strategy, A/B Testing, Cross-Functional Leadership, Enterprise Software, Platform Development, Data-Driven Decision Making, AI Workflows, Building With AI, Automation, Internal Tools, Growth Product Management, Funnel Optimization, Integrations.

--- a/okf/projects.md
+++ b/okf/projects.md
@@ -1,0 +1,34 @@
+---
+type: Project
+title: Personal Projects
+description: Side projects and products built by Kevin Middleton, several of them open-source Claude tools.
+resource: https://middleton.io
+tags: [projects, side-projects, building-with-ai]
+timestamp: 2026-06-30
+---
+
+# Personal Projects
+
+## QuietFeed
+An RSS reader that respects your attention. No algorithm, no AI summarization, just feeds the user controls, with sync, muting and boosting, and article sharing.
+https://quietfeed.com
+
+## Job Search Agent
+Open-source Claude Code plugin that turns Claude into a job-search assistant: scans, tracks, and builds interview guides. The accessible version of the system in his [Personal OS](personal-os.md).
+https://github.com/kevinmmiddleton/job-search-agent
+
+## Personal Site (plugin)
+Open-source Claude plugin that builds a distinctive personal website through a guided interview. No HTML required.
+https://github.com/kevinmmiddleton/personal-site
+
+## Build with Claude
+A step-by-step guide for non-technical people to build apps from their phone with Claude Code and Telegram.
+https://github.com/kevinmmiddleton/build-with-claude
+
+## Visionbort
+A vision board app for setting and tracking goals.
+https://middleton.io/visionbort/
+
+## KevBot
+An AI assistant widget on middleton.io that answers questions about Kevin's background and work.
+https://middleton.io

--- a/okf/skills.md
+++ b/okf/skills.md
@@ -1,0 +1,26 @@
+---
+type: Document
+title: Kevin's Skills and Expertise
+description: Areas of product and technical expertise for Kevin Middleton.
+resource: https://middleton.io
+tags: [skills, expertise, product-management]
+timestamp: 2026-06-30
+---
+
+# Skills and Expertise
+
+## Product
+
+Product Strategy, Roadmapping, A/B Testing, User Research, Funnel Optimization, Growth Product Management, Data-Driven Decision Making, Agile/Scrum.
+
+## Domains
+
+Enterprise SaaS, Consumer SaaS, Platform Products, Internal Tools, Integrations, AI Workflows.
+
+## Building with AI
+
+Ships working software with AI as a non-engineer: specifying and verifying against a goal, building automations, and running a self-hosted system of AI agents. See [building with AI](building-with-ai.md) and [Personal OS](personal-os.md).
+
+## Ways of working
+
+Cross-functional leadership, running meetings, digging into data, building prototypes, turning complex problems into maintainable systems teams can own.

--- a/okf/writing.md
+++ b/okf/writing.md
@@ -1,0 +1,19 @@
+---
+type: Document
+title: Writing
+description: Kevin Middleton writes essays on building with AI, product, and the systems in between. The blog is the source of truth and stays current.
+resource: https://middleton.io/blog/
+tags: [writing, essays, building-with-ai]
+timestamp: 2026-06-30
+---
+
+# Writing
+
+Kevin writes about building with AI, product management, and the systems in between. The full, current list lives at the blog index; a few signature pieces:
+
+- [Everyone can build now. The fundamentals shouldn't change.](https://middleton.io/blog/everyone-can-build-now/): connects to [building with AI](building-with-ai.md).
+- [I Paid to Scrub My Data From Hundreds of Data Brokers. Then I Sent Even More to an AI.](https://middleton.io/blog/owning-your-context/): connects to [owning your context](owning-your-context.md).
+- [I Built an AI Job Search Assistant That Texts Me When It Finds Roles I Should Apply To](https://middleton.io/blog/ai-job-search-assistant/): connects to [Personal OS](personal-os.md).
+- [AI is researching you. Make sure it gets your story right.](https://middleton.io/blog/ai-is-researching-you/): the argument this bundle is built on.
+
+Blog index: https://middleton.io/blog/

--- a/robots.txt
+++ b/robots.txt
@@ -58,3 +58,6 @@ Allow: /
 
 # Sitemap location
 Sitemap: https://middleton.io/sitemap.xml
+
+# Open Knowledge Format (OKF) bundle for AI agents
+# https://middleton.io/okf/index.md

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -270,4 +270,12 @@
     <changefreq>yearly</changefreq>
     <priority>0.7</priority>
   </url>
+
+  <!-- Open Knowledge Format bundle -->
+  <url>
+    <loc>https://middleton.io/okf/index.md</loc>
+    <lastmod>2026-06-30</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## What

Scaffolds an Open Knowledge Format (OKF) bundle for middleton.io. OKF is Google Cloud's v0.1 spec (released 2026-06-12) for machine-readable, agent-friendly knowledge.

## Contents

New `/okf/` directory of 11 Markdown concept files, each with OKF YAML frontmatter (type, title, description, resource, tags, timestamp): index (overview), profile, how-i-work, building-with-ai, personal-os, owning-your-context, skills, case-studies, projects, writing, and contact. It covers both Kevin's portfolio (profile, skills, case studies, projects) and how he builds with AI (Personal OS, building-with-ai, owning-your-context), cross-linked into a graph.

## Discoverability

Bundle added to sitemap.xml, a pointer comment in robots.txt, and a pointer in llms.txt (the discovery convention agents actually read).

## Notes

Content pulled from existing site sources (llms.txt, How I Work page, case-studies index). Nothing invented. Static files only, no build step.

Generated with Claude Code