### PR TITLE
Entity signals: Person @id, Wikidata sameAs + rel=me, AI in knowsAbout

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -17,6 +17,7 @@
     <!-- Identity verification -->
     <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
     <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
     <!-- Open Graph Meta Tags -->
     <meta property="og:title" content="Kevin Middleton - Full Stack Product Manager | Platforms, Internal Tools & AI Workflows">
     <meta property="og:description"
@@ -40,6 +41,7 @@
     {
         "@context": "https://schema.org",
         "@type": "Person",
+        "@id": "https://middleton.io/#kevin",
         "name": "Kevin Middleton",
         "jobTitle": "Full Stack Product Manager",
         "url": "https://middleton.io",
@@ -48,6 +50,7 @@
         "sameAs": [
             "https://www.linkedin.com/in/kevinmiddleton",
             "https://github.com/kevinmmiddleton",
+            "https://www.wikidata.org/wiki/Q140389537",
             "https://calendly.com/kevin-middleton/let-s-talk"
         ],
         "address": {
@@ -63,6 +66,11 @@
         },
         "knowsAbout": [
             "Product Management",
+            "Building with AI",
+            "Generative AI",
+            "Large Language Models",
+            "AI Agents",
+            "Automation",
             "SaaS",
             "Product Strategy",
             "A/B Testing",
@@ -107,13 +115,10 @@
     {
         "@context": "https://schema.org",
         "@type": "WebSite",
+        "@id": "https://middleton.io/#website",
         "name": "Kevin Middleton",
         "url": "https://middleton.io",
-        "author": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io"
-        }
+        "author": { "@id": "https://middleton.io/#kevin" }
     }
     </script>
 


### PR DESCRIPTION
Strengthens entity/identity signals in `index.htm` so search engines and AI agents can resolve Kevin Middleton as a stable entity. Adds a stable `@id` to the Person schema, includes his Wikidata item (Q140389537) in both `sameAs` and a `rel="me"` link, expands `knowsAbout` with AI-building terms (Building with AI, Generative AI, LLMs, AI Agents, Automation), and links the WebSite block to the Person by `@id`. Five exact-match edits, one file; both JSON-LD blocks validated.