### PR TITLE
Homepage copy: "Federal agencies + the grid" → "Federal agencies + grid"

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -145,7 +145,7 @@
     <button class="spec" role="tab" id="tb-platform" aria-controls="sp-platform" aria-selected="false" tabindex="-1"><b>Platforms</b><span>Building for scale</span></button>
     <button class="spec" role="tab" id="tb-integrations" aria-controls="sp-integrations" aria-selected="false" tabindex="-1"><b>Integrations</b><span>SCIM · OAuth · OIDC</span></button>
     <button class="spec" role="tab" id="tb-growth" aria-controls="sp-growth" aria-selected="false" tabindex="-1"><b>Growth</b><span>CRO + A/B testing</span></button>
-    <button class="spec" role="tab" id="tb-gov" aria-controls="sp-gov" aria-selected="false" tabindex="-1"><b>Public Sector</b><span>Federal agencies + the grid</span></button>
+    <button class="spec" role="tab" id="tb-gov" aria-controls="sp-gov" aria-selected="false" tabindex="-1"><b>Public Sector</b><span>Federal agencies + grid</span></button>
   </div>
   <div class="spec-stage rv d2">
     <div class="spec-panel" role="tabpanel" id="sp-ai" aria-labelledby="tb-ai">


### PR DESCRIPTION
One-word copy change to the Public Sector specialty card subtitle on the homepage.

No CSS, markup or behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)