### PR TITLE
Homepage copy: contact button reads "Office Hours"

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -418,7 +418,7 @@
   <h2 class="rv">Bring me something <em>messy.</em></h2>
   <div class="cbtns rv d2">
     <a class="cb c-mail plausible-event-name=Contact+Email" href="mailto:kevin@middleton.io">kevin@middleton.io</a>
-    <a class="cb c-oh plausible-event-name=Contact+OfficeHours" href="/officehours/" target="_blank" rel="noopener noreferrer">Office Hours · free, all week</a>
+    <a class="cb c-oh plausible-event-name=Contact+OfficeHours" href="/officehours/" target="_blank" rel="noopener noreferrer">Office Hours</a>
     <a class="cb c-li plausible-event-name=Contact+LinkedIn" href="https://linkedin.com/in/kevinmiddleton" target="_blank" rel="noopener noreferrer">LinkedIn</a>
       <a class="cb c-gh plausible-event-name=GitHub+Click" href="https://github.com/kevinmmiddleton" target="_blank" rel="noopener noreferrer">GitHub</a>
   </div>


### PR DESCRIPTION
Shortens the contact-row button from "Office Hours · free, all week" to "Office Hours".

Link target and the `Contact+OfficeHours` Plausible event are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)