### PR TITLE
Nav: "Writing" → "Blog", opens in a new tab

### DIFF
--- a/blog/ai-guilt-is-the-new-recycling/index.html
+++ b/blog/ai-guilt-is-the-new-recycling/index.html
@@ -114,7 +114,7 @@
           <a href="/#about">About</a>
           <a href="/#record">Experience</a>
           <a href="/#cases">Case Studies</a>
-          <a href="/blog/">Writing</a>
+          <a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a>
         </span>
         <a class="cta plausible-event-name=Header+OfficeHours" href="/officehours/">Office Hours</a>
       </nav>

--- a/blog/ai-is-researching-you/index.html
+++ b/blog/ai-is-researching-you/index.html
@@ -113,7 +113,7 @@
           <a href="/#about">About</a>
           <a href="/#record">Experience</a>
           <a href="/#cases">Case Studies</a>
-          <a href="/blog/">Writing</a>
+          <a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a>
         </span>
         <a class="cta plausible-event-name=Header+OfficeHours" href="/officehours/">Office Hours</a>
       </nav>

--- a/blog/ai-job-scanner-daily/index.html
+++ b/blog/ai-job-scanner-daily/index.html
@@ -116,7 +116,7 @@
           <a href="/#about">About</a>
           <a href="/#record">Experience</a>
           <a href="/#cases">Case Studies</a>
-          <a href="/blog/">Writing</a>
+          <a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a>
         </span>
         <a class="cta plausible-event-name=Header+OfficeHours" href="/officehours/">Office Hours</a>
       </nav>

--- a/blog/ai-job-search-assistant/index.html
+++ b/blog/ai-job-search-assistant/index.html
@@ -117,7 +117,7 @@
           <a href="/#about">About</a>
           <a href="/#record">Experience</a>
           <a href="/#cases">Case Studies</a>
-          <a href="/blog/">Writing</a>
+          <a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a>
         </span>
         <a class="cta plausible-event-name=Header+OfficeHours" href="/officehours/">Office Hours</a>
       </nav>

--- a/blog/ai-tools-non-technical/index.html
+++ b/blog/ai-tools-non-technical/index.html
@@ -116,7 +116,7 @@
           <a href="/#about">About</a>
           <a href="/#record">Experience</a>
           <a href="/#cases">Case Studies</a>
-          <a href="/blog/">Writing</a>
+          <a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a>
         </span>
         <a class="cta plausible-event-name=Header+OfficeHours" href="/officehours/">Office Hours</a>
       </nav>

--- a/blog/applying-for-jobs-is-like-stand-up-comedy/index.html
+++ b/blog/applying-for-jobs-is-like-stand-up-comedy/index.html
@@ -114,7 +114,7 @@
           <a href="/#about">About</a>
           <a href="/#record">Experience</a>
           <a href="/#cases">Case Studies</a>
-          <a href="/blog/">Writing</a>
+          <a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a>
         </span>
         <a class="cta plausible-event-name=Header+OfficeHours" href="/officehours/">Office Hours</a>
       </nav>

--- a/blog/build-with-claude/index.html
+++ b/blog/build-with-claude/index.html
@@ -113,7 +113,7 @@
           <a href="/#about">About</a>
           <a href="/#record">Experience</a>
           <a href="/#cases">Case Studies</a>
-          <a href="/blog/">Writing</a>
+          <a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a>
         </span>
         <a class="cta plausible-event-name=Header+OfficeHours" href="/officehours/">Office Hours</a>
       </nav>

--- a/blog/curiosity-makes-or-breaks/index.html
+++ b/blog/curiosity-makes-or-breaks/index.html
@@ -114,7 +114,7 @@
           <a href="/#about">About</a>
           <a href="/#record">Experience</a>
           <a href="/#cases">Case Studies</a>
-          <a href="/blog/">Writing</a>
+          <a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a>
         </span>
         <a class="cta plausible-event-name=Header+OfficeHours" href="/officehours/">Office Hours</a>
       </nav>

--- a/blog/everyone-can-build-now/index.html
+++ b/blog/everyone-can-build-now/index.html
@@ -115,7 +115,7 @@
           <a href="/#about">About</a>
           <a href="/#record">Experience</a>
           <a href="/#cases">Case Studies</a>
-          <a href="/blog/">Writing</a>
+          <a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a>
         </span>
         <a class="cta plausible-event-name=Header+OfficeHours" href="/officehours/">Office Hours</a>
       </nav>

--- a/blog/index.html
+++ b/blog/index.html
@@ -176,7 +176,7 @@
           <a href="/#about">About</a>
           <a href="/#record">Experience</a>
           <a href="/#cases">Case Studies</a>
-          <a href="/blog/">Writing</a>
+          <a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a>
         </span>
         <a class="cta plausible-event-name=Header+OfficeHours" href="/officehours/">Office Hours</a>
       </nav>

--- a/blog/its-almost-always-the-resume/index.html
+++ b/blog/its-almost-always-the-resume/index.html
@@ -114,7 +114,7 @@
           <a href="/#about">About</a>
           <a href="/#record">Experience</a>
           <a href="/#cases">Case Studies</a>
-          <a href="/blog/">Writing</a>
+          <a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a>
         </span>
         <a class="cta plausible-event-name=Header+OfficeHours" href="/officehours/">Office Hours</a>
       </nav>

--- a/blog/job-search-agent/index.html
+++ b/blog/job-search-agent/index.html
@@ -114,7 +114,7 @@
           <a href="/#about">About</a>
           <a href="/#record">Experience</a>
           <a href="/#cases">Case Studies</a>
-          <a href="/blog/">Writing</a>
+          <a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a>
         </span>
         <a class="cta plausible-event-name=Header+OfficeHours" href="/officehours/">Office Hours</a>
       </nav>

--- a/blog/one-page-you-own/index.html
+++ b/blog/one-page-you-own/index.html
@@ -114,7 +114,7 @@
           <a href="/#about">About</a>
           <a href="/#record">Experience</a>
           <a href="/#cases">Case Studies</a>
-          <a href="/blog/">Writing</a>
+          <a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a>
         </span>
         <a class="cta plausible-event-name=Header+OfficeHours" href="/officehours/">Office Hours</a>
       </nav>

--- a/blog/owning-your-context/index.html
+++ b/blog/owning-your-context/index.html
@@ -116,7 +116,7 @@
           <a href="/#about">About</a>
           <a href="/#record">Experience</a>
           <a href="/#cases">Case Studies</a>
-          <a href="/blog/">Writing</a>
+          <a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a>
         </span>
         <a class="cta plausible-event-name=Header+OfficeHours" href="/officehours/">Office Hours</a>
       </nav>

--- a/blog/product-management-is-dead/index.html
+++ b/blog/product-management-is-dead/index.html
@@ -114,7 +114,7 @@
           <a href="/#about">About</a>
           <a href="/#record">Experience</a>
           <a href="/#cases">Case Studies</a>
-          <a href="/blog/">Writing</a>
+          <a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a>
         </span>
         <a class="cta plausible-event-name=Header+OfficeHours" href="/officehours/">Office Hours</a>
       </nav>

--- a/blog/twice-a-day/index.html
+++ b/blog/twice-a-day/index.html
@@ -113,7 +113,7 @@
           <a href="/#about">About</a>
           <a href="/#record">Experience</a>
           <a href="/#cases">Case Studies</a>
-          <a href="/blog/">Writing</a>
+          <a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a>
         </span>
         <a class="cta plausible-event-name=Header+OfficeHours" href="/officehours/">Office Hours</a>
       </nav>

--- a/index.htm
+++ b/index.htm
@@ -113,7 +113,7 @@
   <span class="mk">Kevin Middleton<small>Full Stack Product Manager &middot; New York City</small></span>
   <span class="nav-l">
     <a href="#building">Building</a><a href="#about">About</a><a href="#values">Values</a>
-    <a href="#record">Experience</a><a href="#cases">Case Studies</a><a href="/blog/">Writing</a>
+    <a href="#record">Experience</a><a href="#cases">Case Studies</a><a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a>
   </span>
   <a class="cta plausible-event-name=Header+OfficeHours" href="/officehours/" target="_blank" rel="noopener noreferrer">Office Hours</a>
 </nav>

--- a/prototypes/index.html
+++ b/prototypes/index.html
@@ -78,7 +78,7 @@
     <a href="/#about">About</a>
     <a href="/#record">Experience</a>
     <a href="/#cases">Case Studies</a>
-    <a href="/blog/">Writing</a>
+    <a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a>
   </span>
   <a class="cta plausible-event-name=Header+OfficeHours" href="/officehours/">Office Hours</a>
 </nav>

--- a/tools/blog-generate.mjs
+++ b/tools/blog-generate.mjs
@@ -181,7 +181,7 @@ const HEADER = `    <nav class="nav pad">
           <a href="/#about">About</a>
           <a href="/#record">Experience</a>
           <a href="/#cases">Case Studies</a>
-          <a href="/blog/">Writing</a>
+          <a href="/blog/" target="_blank" rel="noopener noreferrer">Blog</a>
         </span>
         <a class="cta plausible-event-name=Header+OfficeHours" href="/officehours/">Office Hours</a>
       </nav>`;


### PR DESCRIPTION
Renames the nav item from "Writing" to "Blog" and gives it `target="_blank"` with `rel="noopener noreferrer"`.

Applied to the homepage, prototypes, all 16 blog pages, and the generator template so regeneration preserves it. Verified the generator is still idempotent.

Left alone: the footer colophon `/blog/` link (already "Blog", same tab) and the KevinOS desktop icon labelled "Writing", which is an app icon rather than site nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)