### PR TITLE
Connect band: "messy." keeps the marigold in dark mode

### DIFF
--- a/blog/ai-guilt-is-the-new-recycling/index.html
+++ b/blog/ai-guilt-is-the-new-recycling/index.html
@@ -29,7 +29,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/ai-is-researching-you/index.html
+++ b/blog/ai-is-researching-you/index.html
@@ -29,7 +29,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/ai-job-scanner-daily/index.html
+++ b/blog/ai-job-scanner-daily/index.html
@@ -29,7 +29,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/ai-job-search-assistant/index.html
+++ b/blog/ai-job-search-assistant/index.html
@@ -29,7 +29,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/ai-tools-non-technical/index.html
+++ b/blog/ai-tools-non-technical/index.html
@@ -29,7 +29,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/applying-for-jobs-is-like-stand-up-comedy/index.html
+++ b/blog/applying-for-jobs-is-like-stand-up-comedy/index.html
@@ -29,7 +29,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/build-with-claude/index.html
+++ b/blog/build-with-claude/index.html
@@ -29,7 +29,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/curiosity-makes-or-breaks/index.html
+++ b/blog/curiosity-makes-or-breaks/index.html
@@ -29,7 +29,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/everyone-can-build-now/index.html
+++ b/blog/everyone-can-build-now/index.html
@@ -29,7 +29,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/index.html
+++ b/blog/index.html
@@ -27,7 +27,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/its-almost-always-the-resume/index.html
+++ b/blog/its-almost-always-the-resume/index.html
@@ -29,7 +29,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/job-search-agent/index.html
+++ b/blog/job-search-agent/index.html
@@ -29,7 +29,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/one-page-you-own/index.html
+++ b/blog/one-page-you-own/index.html
@@ -29,7 +29,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/owning-your-context/index.html
+++ b/blog/owning-your-context/index.html
@@ -29,7 +29,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/product-management-is-dead/index.html
+++ b/blog/product-management-is-dead/index.html
@@ -29,7 +29,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/twice-a-day/index.html
+++ b/blog/twice-a-day/index.html
@@ -29,7 +29,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/casestudies/case-study-hvac.html
+++ b/casestudies/case-study-hvac.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Turning Traffic Into Intent: Calculators & Conversion at HVAC.com">
     <meta name="twitter:description" content="Built high-intent calculators that converted at 50x the site baseline.">
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
     {

--- a/casestudies/case-study-lever.html
+++ b/casestudies/case-study-lever.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Moving Lever Upmarket: Bulk Import & HRIS Sync">
     <meta name="twitter:description" content="How we proved Lever could operate at enterprise scale.">
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
     {

--- a/casestudies/case-study-oracle.html
+++ b/casestudies/case-study-oracle.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Scaling Social: Platform Overhaul & Network Expansion at Oracle">
     <meta name="twitter:description" content="Led a year-long platform modernization, doubling social network coverage.">
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
     {

--- a/casestudies/case-study-rocketlawyer-covea.html
+++ b/casestudies/case-study-rocketlawyer-covea.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Co-Branded Partner Sites at Rocket Lawyer">
     <meta name="twitter:description" content="How we launched Rocket Lawyer's first enterprise partnership.">
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
     {

--- a/casestudies/case-study-rocketlawyer-mobile.html
+++ b/casestudies/case-study-rocketlawyer-mobile.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Mobile Conversion Optimization at Rocket Lawyer">
     <meta name="twitter:description" content="Drove a 5% conversion lift through targeted A/B testing on mobile.">
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
     {

--- a/casestudies/case-study-sendoso.html
+++ b/casestudies/case-study-sendoso.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="eGift Platform Expansion & Square Partnership at Sendoso">
     <meta name="twitter:description" content="Scaled catalog coverage and landed strategic partnerships at Sendoso.">
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
     {

--- a/casestudies/index.html
+++ b/casestudies/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#F4F4F5" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0F0F12" media="(prefers-color-scheme: dark)">
     <title>Case Studies | Kevin Middleton</title>
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <meta name="description"
         content="Selected product case studies from Kevin Middleton — conversion optimization, 0-to-1 products, enterprise partnerships, and platform modernization.">
     <link rel="icon" type="image/x-icon" href="https://middleton.io/favicon.ico">

--- a/fv.css
+++ b/fv.css
@@ -3210,3 +3210,12 @@ html:has(.fv){scroll-behavior:smooth;scroll-padding-top:5rem}
    of the 24px numerals and it rendered at 9px. */
 body.p-case .metric-value .arw{font-size:inherit;width:.9em;height:.9em;
   vertical-align:-.08em;margin-inline:.16em}
+
+
+/* "messy." holds the light-mode marigold in dark mode too. The connect panel
+   inverts (dark band on a light page, light band on a dark page), so the shared
+   --gold-on-invert darkens to #815B0C in dark to stay legible on the light
+   band. Kevin's call: at 67px the marigold reads fine there and the brand
+   colour matters more. --marigold is theme-invariant, so this pins it. Scoped
+   to this one element; --gold-on-invert is untouched for any other use. */
+.fv .connect h2 em{color:var(--marigold)}

--- a/index.htm
+++ b/index.htm
@@ -105,7 +105,7 @@
 </head>
 <body>
 
-<link rel="stylesheet" href="/fv.css?v=5850c40f">
+<link rel="stylesheet" href="/fv.css?v=b7966cd1">
 
 <div class="fv">
 

--- a/prototypes/index.html
+++ b/prototypes/index.html
@@ -16,7 +16,7 @@
 <meta name="twitter:card" content="summary_large_image">
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/fv.css?v=5850c40f">
+<link rel="stylesheet" href="/fv.css?v=b7966cd1">
 <script type="application/ld+json">
 {
     "@context": "https://schema.org",

--- a/recipes/index.html
+++ b/recipes/index.html
@@ -23,7 +23,7 @@
 
   <link rel="icon" href="https://middleton.io/recipes/images/chef-technologist.webp">
   <link rel="apple-touch-icon" href="https://middleton.io/recipes/images/chef-technologist.webp">
-  <link rel="stylesheet" href="/fv.css?v=5850c40f">
+  <link rel="stylesheet" href="/fv.css?v=b7966cd1">
 <script async src="https://plausible.io/js/pa-CycHtdoRKtjDMtDpjBTA4.js"></script>
 <script>
   window.plausible = window.plausible || function () { (plausible.q = plausible.q || []).push(arguments) }, plausible.init = plausible.init || function (i) { plausible.o = i || {} };

--- a/slides/index.html
+++ b/slides/index.html
@@ -28,7 +28,7 @@
 
 
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🤑</text></svg>" />
-<link rel="stylesheet" href="/fv.css?v=5850c40f">
+<link rel="stylesheet" href="/fv.css?v=b7966cd1">
 
 <!-- Privacy-friendly analytics -->
 <script async src="https://plausible.io/js/pa-OjFchTSjmO38TDwmb0xU5.js"></script>

--- a/tools/blog-generate.mjs
+++ b/tools/blog-generate.mjs
@@ -164,7 +164,7 @@ function seriesCallouts(post, all) {
 // ---------- shared chrome ----------
 const HEAD_LINKS = `    <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=5850c40f">
+    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">`;


### PR DESCRIPTION
The connect panel inverts between themes, so in dark mode "messy." sits on a light band and the shared `--gold-on-invert` darkens to `#815B0C` to stay legible.

Kevin's call: at 67px the marigold reads fine there and the brand colour matters more. Pinned with `--marigold` (theme-invariant), scoped to `.fv .connect h2 em` only. `--gold-on-invert` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)