### PR TITLE
SEO: consolidate the identity graph onto one entity

### DIFF
--- a/blog/ai-guilt-is-the-new-recycling/index.html
+++ b/blog/ai-guilt-is-the-new-recycling/index.html
@@ -33,6 +33,12 @@
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <!-- Identity verification. Same three profiles the homepage claims, so every
+         page resolves to one entity rather than a separate author blob.
+         Wikidata is the disambiguating anchor. -->
+    <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
+    <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
 
     <!-- JSON-LD: Article -->
     <script type="application/ld+json">
@@ -43,12 +49,18 @@
         "description": "AI guilt is everywhere, and it is landing on exhausted people instead of the leaders who earned it. We have done this before. Last time we called it recycling.",
         "author": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+            "sameAs": [
+                "https://www.linkedin.com/in/kevinmiddleton/",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ]
         },
         "publisher": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io"
         },

--- a/blog/ai-is-researching-you/index.html
+++ b/blog/ai-is-researching-you/index.html
@@ -33,6 +33,12 @@
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <!-- Identity verification. Same three profiles the homepage claims, so every
+         page resolves to one entity rather than a separate author blob.
+         Wikidata is the disambiguating anchor. -->
+    <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
+    <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
 
     <!-- JSON-LD: Article -->
     <script type="application/ld+json">
@@ -43,12 +49,18 @@
         "description": "ChatGPT showed up in my site's referrer logs. Companies are worrying about how they appear in AI search. The same logic applies to many of us.",
         "author": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+            "sameAs": [
+                "https://www.linkedin.com/in/kevinmiddleton/",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ]
         },
         "publisher": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io"
         },

--- a/blog/ai-job-scanner-daily/index.html
+++ b/blog/ai-job-scanner-daily/index.html
@@ -33,6 +33,12 @@
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <!-- Identity verification. Same three profiles the homepage claims, so every
+         page resolves to one entity rather than a separate author blob.
+         Wikidata is the disambiguating anchor. -->
+    <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
+    <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
 
     <!-- JSON-LD: Article -->
     <script type="application/ld+json">
@@ -43,12 +49,18 @@
         "description": "Two weeks running my AI job scanner. The field report: extraction failures, a temporary block, duplicate noise, and what actually held up.",
         "author": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+            "sameAs": [
+                "https://www.linkedin.com/in/kevinmiddleton/",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ]
         },
         "publisher": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io"
         },

--- a/blog/ai-job-search-assistant/index.html
+++ b/blog/ai-job-search-assistant/index.html
@@ -33,6 +33,12 @@
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <!-- Identity verification. Same three profiles the homepage claims, so every
+         page resolves to one entity rather than a separate author blob.
+         Wikidata is the disambiguating anchor. -->
+    <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
+    <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
 
     <!-- JSON-LD: Article -->
     <script type="application/ld+json">
@@ -43,12 +49,18 @@
         "description": "How a Mac Mini in my apartment scans LinkedIn twice a day, filters for roles that match my profile, and texts me the results, for about six cents a day.",
         "author": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+            "sameAs": [
+                "https://www.linkedin.com/in/kevinmiddleton/",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ]
         },
         "publisher": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io"
         },

--- a/blog/ai-tools-non-technical/index.html
+++ b/blog/ai-tools-non-technical/index.html
@@ -33,6 +33,12 @@
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <!-- Identity verification. Same three profiles the homepage claims, so every
+         page resolves to one entity rather than a separate author blob.
+         Wikidata is the disambiguating anchor. -->
+    <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
+    <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
 
     <!-- JSON-LD: Article -->
     <script type="application/ld+json">
@@ -43,12 +49,18 @@
         "description": "I built a job scanner that runs while I sleep. I couldn't hand it to a smart, motivated friend. The gap between 'I want that' and 'I can do that' is still enormous.",
         "author": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+            "sameAs": [
+                "https://www.linkedin.com/in/kevinmiddleton/",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ]
         },
         "publisher": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io"
         },

--- a/blog/applying-for-jobs-is-like-stand-up-comedy/index.html
+++ b/blog/applying-for-jobs-is-like-stand-up-comedy/index.html
@@ -33,6 +33,12 @@
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <!-- Identity verification. Same three profiles the homepage claims, so every
+         page resolves to one entity rather than a separate author blob.
+         Wikidata is the disambiguating anchor. -->
+    <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
+    <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
 
     <!-- JSON-LD: Article -->
     <script type="application/ld+json">
@@ -43,12 +49,18 @@
         "description": "A lot of the standard job search advice is bunk, and the rest is easier to follow if you treat the whole thing like an open mic. Go up rusty, test your material, learn to handle hecklers.",
         "author": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+            "sameAs": [
+                "https://www.linkedin.com/in/kevinmiddleton/",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ]
         },
         "publisher": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io"
         },

--- a/blog/build-with-claude/index.html
+++ b/blog/build-with-claude/index.html
@@ -33,6 +33,12 @@
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <!-- Identity verification. Same three profiles the homepage claims, so every
+         page resolves to one entity rather than a separate author blob.
+         Wikidata is the disambiguating anchor. -->
+    <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
+    <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
 
     <!-- JSON-LD: Article -->
     <script type="application/ld+json">
@@ -43,12 +49,18 @@
         "description": "No code, no IDE, just a Telegram message. A Mac at home runs Claude Code, and a free guide gets you the same setup.",
         "author": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+            "sameAs": [
+                "https://www.linkedin.com/in/kevinmiddleton/",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ]
         },
         "publisher": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io"
         },

--- a/blog/curiosity-makes-or-breaks/index.html
+++ b/blog/curiosity-makes-or-breaks/index.html
@@ -33,6 +33,12 @@
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <!-- Identity verification. Same three profiles the homepage claims, so every
+         page resolves to one entity rather than a separate author blob.
+         Wikidata is the disambiguating anchor. -->
+    <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
+    <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
 
     <!-- JSON-LD: Article -->
     <script type="application/ld+json">
@@ -43,12 +49,18 @@
         "description": "You can usually tell within a few weeks whether you'll thrive at a company or just survive it. It comes down to what happens when you ask one simple question.",
         "author": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+            "sameAs": [
+                "https://www.linkedin.com/in/kevinmiddleton/",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ]
         },
         "publisher": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io"
         },

--- a/blog/everyone-can-build-now/index.html
+++ b/blog/everyone-can-build-now/index.html
@@ -33,6 +33,12 @@
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <!-- Identity verification. Same three profiles the homepage claims, so every
+         page resolves to one entity rather than a separate author blob.
+         Wikidata is the disambiguating anchor. -->
+    <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
+    <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
 
     <!-- JSON-LD: Article -->
     <script type="application/ld+json">
@@ -43,12 +49,18 @@
         "description": "AI made everyone a builder. It didn't say who orchestrates them, or who validates and integrates all the prototypes.",
         "author": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+            "sameAs": [
+                "https://www.linkedin.com/in/kevinmiddleton/",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ]
         },
         "publisher": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io"
         },

--- a/blog/index.html
+++ b/blog/index.html
@@ -31,6 +31,12 @@
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <!-- Identity verification. Same three profiles the homepage claims, so every
+         page resolves to one entity rather than a separate author blob.
+         Wikidata is the disambiguating anchor. -->
+    <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
+    <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
 
     <!-- JSON-LD: Blog + posts -->
     <script type="application/ld+json">
@@ -41,6 +47,7 @@
         "url": "https://middleton.io/blog/",
         "author": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io"
         },

--- a/blog/its-almost-always-the-resume/index.html
+++ b/blog/its-almost-always-the-resume/index.html
@@ -33,6 +33,12 @@
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <!-- Identity verification. Same three profiles the homepage claims, so every
+         page resolves to one entity rather than a separate author blob.
+         Wikidata is the disambiguating anchor. -->
+    <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
+    <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
 
     <!-- JSON-LD: Article -->
     <script type="application/ld+json">
@@ -43,12 +49,18 @@
         "description": "When a search stalls, people blame the ATS, the AI, the economy. Almost every time I look, it's the resume. So I overhauled my own. Here's exactly what changed and why.",
         "author": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+            "sameAs": [
+                "https://www.linkedin.com/in/kevinmiddleton/",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ]
         },
         "publisher": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io"
         },

--- a/blog/job-search-agent/index.html
+++ b/blog/job-search-agent/index.html
@@ -33,6 +33,12 @@
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <!-- Identity verification. Same three profiles the homepage claims, so every
+         page resolves to one entity rather than a separate author blob.
+         Wikidata is the disambiguating anchor. -->
+    <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
+    <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
 
     <!-- JSON-LD: Article -->
     <script type="application/ld+json">
@@ -43,12 +49,18 @@
         "description": "Open-sourced a Claude Code plugin that turns Claude into your job search assistant. The accessible version of the system I built for myself, free on GitHub.",
         "author": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+            "sameAs": [
+                "https://www.linkedin.com/in/kevinmiddleton/",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ]
         },
         "publisher": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io"
         },

--- a/blog/one-page-you-own/index.html
+++ b/blog/one-page-you-own/index.html
@@ -33,6 +33,12 @@
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <!-- Identity verification. Same three profiles the homepage claims, so every
+         page resolves to one entity rather than a separate author blob.
+         Wikidata is the disambiguating anchor. -->
+    <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
+    <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
 
     <!-- JSON-LD: Article -->
     <script type="application/ld+json">
@@ -43,12 +49,18 @@
         "description": "An old colleague got laid off, shipped a personal site ten days after I sent him a starter kit, and took back his story online. So I turned the starter into a free plugin.",
         "author": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+            "sameAs": [
+                "https://www.linkedin.com/in/kevinmiddleton/",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ]
         },
         "publisher": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io"
         },

--- a/blog/owning-your-context/index.html
+++ b/blog/owning-your-context/index.html
@@ -33,6 +33,12 @@
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <!-- Identity verification. Same three profiles the homepage claims, so every
+         page resolves to one entity rather than a separate author blob.
+         Wikidata is the disambiguating anchor. -->
+    <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
+    <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
 
     <!-- JSON-LD: Article -->
     <script type="application/ld+json">
@@ -43,12 +49,18 @@
         "description": "I pay a service to scrub my data from hundreds of brokers. Then I hand an AI my taxes, my finances, my fears. Where should that personal context actually live?",
         "author": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+            "sameAs": [
+                "https://www.linkedin.com/in/kevinmiddleton/",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ]
         },
         "publisher": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io"
         },

--- a/blog/product-management-is-dead/index.html
+++ b/blog/product-management-is-dead/index.html
@@ -33,6 +33,12 @@
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <!-- Identity verification. Same three profiles the homepage claims, so every
+         page resolves to one entity rather than a separate author blob.
+         Wikidata is the disambiguating anchor. -->
+    <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
+    <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
 
     <!-- JSON-LD: Article -->
     <script type="application/ld+json">
@@ -43,12 +49,18 @@
         "description": "We keep killing product management. It keeps coming back.",
         "author": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+            "sameAs": [
+                "https://www.linkedin.com/in/kevinmiddleton/",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ]
         },
         "publisher": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io"
         },

--- a/blog/twice-a-day/index.html
+++ b/blog/twice-a-day/index.html
@@ -33,6 +33,12 @@
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <!-- Identity verification. Same three profiles the homepage claims, so every
+         page resolves to one entity rather than a separate author blob.
+         Wikidata is the disambiguating anchor. -->
+    <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
+    <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
 
     <!-- JSON-LD: Article -->
     <script type="application/ld+json">
@@ -43,12 +49,18 @@
         "description": "I check my inbox twice a day. Here's what a morning briefing from my AI assistant gave me back in a brutal job market.",
         "author": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+            "sameAs": [
+                "https://www.linkedin.com/in/kevinmiddleton/",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ]
         },
         "publisher": {
             "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
             "name": "Kevin Middleton",
             "url": "https://middleton.io"
         },

--- a/casestudies/case-study-hvac.html
+++ b/casestudies/case-study-hvac.html
@@ -23,34 +23,43 @@
     <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "Article",
-        "headline": "Turning Traffic Into Intent: Calculators & Conversion at HVAC.com",
-        "description": "Built high-intent tools from scratch that converted at 50x the site baseline, turning a high-traffic homeowner platform into a lead generation engine.",
-        "author": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        },
-        "publisher": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io"
-        },
-        "mainEntityOfPage": {
-            "@type": "WebPage",
-            "@id": "https://middleton.io/casestudies/case-study-hvac.html"
-        },
-        "url": "https://middleton.io/casestudies/case-study-hvac.html",
-        "image": "https://middleton.io/images/hvac-calculators.png",
-        "articleSection": "Case Study",
-        "keywords": ["Product Management", "Conversion Rate Optimization", "A/B Testing", "HVAC", "Lead Generation", "SaaS"],
-        "datePublished": "2024-01-01",
-        "dateModified": "2026-04-15"
-    }
-    </script>
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Turning Traffic Into Intent: Calculators & Conversion at HVAC.com",
+  "description": "Built high-intent tools from scratch that converted at 50x the site baseline, turning a high-traffic homeowner platform into a lead generation engine.",
+  "author": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  },
+  "publisher": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://middleton.io/casestudies/case-study-hvac.html"
+  },
+  "url": "https://middleton.io/casestudies/case-study-hvac.html",
+  "image": "https://middleton.io/images/hvac-calculators.png",
+  "articleSection": "Case Study",
+  "keywords": [
+    "Product Management",
+    "Conversion Rate Optimization",
+    "A/B Testing",
+    "HVAC",
+    "Lead Generation",
+    "SaaS"
+  ],
+  "datePublished": "2024-01-01",
+  "dateModified": "2026-04-15"
+}
+</script>
     <!-- Privacy-friendly analytics by Plausible -->
     <script async src="https://plausible.io/js/pa-CycHtdoRKtjDMtDpjBTA4.js"></script>
     <script>

--- a/casestudies/case-study-lever.html
+++ b/casestudies/case-study-lever.html
@@ -23,34 +23,42 @@
     <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "Article",
-        "headline": "Moving Lever Upmarket: Bulk Import & HRIS Sync",
-        "description": "How we proved Lever could operate at enterprise scale. First by eliminating implementation friction, then by building enterprise-grade user management.",
-        "author": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        },
-        "publisher": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io"
-        },
-        "mainEntityOfPage": {
-            "@type": "WebPage",
-            "@id": "https://middleton.io/casestudies/case-study-lever.html"
-        },
-        "url": "https://middleton.io/casestudies/case-study-lever.html",
-        "image": "https://middleton.io/images/lever-logo.webp",
-        "articleSection": "Case Study",
-        "keywords": ["Product Management", "HRIS Integration", "Enterprise SaaS", "HR Tech", "User Provisioning"],
-        "datePublished": "2024-01-01",
-        "dateModified": "2026-04-15"
-    }
-    </script>
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Moving Lever Upmarket: Bulk Import & HRIS Sync",
+  "description": "How we proved Lever could operate at enterprise scale. First by eliminating implementation friction, then by building enterprise-grade user management.",
+  "author": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  },
+  "publisher": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://middleton.io/casestudies/case-study-lever.html"
+  },
+  "url": "https://middleton.io/casestudies/case-study-lever.html",
+  "image": "https://middleton.io/images/lever-logo.webp",
+  "articleSection": "Case Study",
+  "keywords": [
+    "Product Management",
+    "HRIS Integration",
+    "Enterprise SaaS",
+    "HR Tech",
+    "User Provisioning"
+  ],
+  "datePublished": "2024-01-01",
+  "dateModified": "2026-04-15"
+}
+</script>
     <!-- Privacy-friendly analytics by Plausible -->
 <script async src="https://plausible.io/js/pa-jT7b-g_RtDUwXjON-J767.js"></script>
 <script>

--- a/casestudies/case-study-oracle.html
+++ b/casestudies/case-study-oracle.html
@@ -23,34 +23,43 @@
     <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "Article",
-        "headline": "Scaling Social: Platform Overhaul & Network Expansion at Oracle",
-        "description": "Led a year-long platform modernization, doubling social network coverage and shipping 36 features across UI, performance, and internationalization.",
-        "author": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        },
-        "publisher": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io"
-        },
-        "mainEntityOfPage": {
-            "@type": "WebPage",
-            "@id": "https://middleton.io/casestudies/case-study-oracle.html"
-        },
-        "url": "https://middleton.io/casestudies/case-study-oracle.html",
-        "image": "https://middleton.io/images/oracle-engage-v2.png",
-        "articleSection": "Case Study",
-        "keywords": ["Product Management", "Social Media", "Enterprise Software", "Internationalization", "Platform Modernization", "Oracle"],
-        "datePublished": "2024-01-01",
-        "dateModified": "2026-04-15"
-    }
-    </script>
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Scaling Social: Platform Overhaul & Network Expansion at Oracle",
+  "description": "Led a year-long platform modernization, doubling social network coverage and shipping 36 features across UI, performance, and internationalization.",
+  "author": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  },
+  "publisher": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://middleton.io/casestudies/case-study-oracle.html"
+  },
+  "url": "https://middleton.io/casestudies/case-study-oracle.html",
+  "image": "https://middleton.io/images/oracle-engage-v2.png",
+  "articleSection": "Case Study",
+  "keywords": [
+    "Product Management",
+    "Social Media",
+    "Enterprise Software",
+    "Internationalization",
+    "Platform Modernization",
+    "Oracle"
+  ],
+  "datePublished": "2024-01-01",
+  "dateModified": "2026-04-15"
+}
+</script>
     <!-- Privacy-friendly analytics by Plausible -->
 <script async src="https://plausible.io/js/pa-8-BhCQFQTZrglXDJEKfS-.js"></script>
 <script>

--- a/casestudies/case-study-rocketlawyer-covea.html
+++ b/casestudies/case-study-rocketlawyer-covea.html
@@ -23,34 +23,43 @@
     <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "Article",
-        "headline": "Co-Branded Partner Sites at Rocket Lawyer",
-        "description": "One integration. Six months. How we launched Rocket Lawyer's first enterprise partnership and built a platform for the next ten.",
-        "author": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        },
-        "publisher": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io"
-        },
-        "mainEntityOfPage": {
-            "@type": "WebPage",
-            "@id": "https://middleton.io/casestudies/case-study-rocketlawyer-covea.html"
-        },
-        "url": "https://middleton.io/casestudies/case-study-rocketlawyer-covea.html",
-        "image": "https://middleton.io/images/covea-login-screen.png",
-        "articleSection": "Case Study",
-        "keywords": ["Product Management", "Enterprise Partnerships", "Legal Tech", "B2B", "Platform Development", "White Label"],
-        "datePublished": "2024-01-01",
-        "dateModified": "2026-04-15"
-    }
-    </script>
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Co-Branded Partner Sites at Rocket Lawyer",
+  "description": "One integration. Six months. How we launched Rocket Lawyer's first enterprise partnership and built a platform for the next ten.",
+  "author": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  },
+  "publisher": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://middleton.io/casestudies/case-study-rocketlawyer-covea.html"
+  },
+  "url": "https://middleton.io/casestudies/case-study-rocketlawyer-covea.html",
+  "image": "https://middleton.io/images/covea-login-screen.png",
+  "articleSection": "Case Study",
+  "keywords": [
+    "Product Management",
+    "Enterprise Partnerships",
+    "Legal Tech",
+    "B2B",
+    "Platform Development",
+    "White Label"
+  ],
+  "datePublished": "2024-01-01",
+  "dateModified": "2026-04-15"
+}
+</script>
     <!-- Privacy-friendly analytics by Plausible -->
 <script async src="https://plausible.io/js/pa-EjHecMcfwGKDLQNSORlAf.js"></script>
 <script>

--- a/casestudies/case-study-rocketlawyer-mobile.html
+++ b/casestudies/case-study-rocketlawyer-mobile.html
@@ -23,34 +23,43 @@
     <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "Article",
-        "headline": "Mobile Conversion Optimization at Rocket Lawyer",
-        "description": "Failed fast on desktop. Won big on mobile. Drove a 5% conversion lift for Rocket Lawyer's highest-revenue product line through targeted A/B testing.",
-        "author": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        },
-        "publisher": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io"
-        },
-        "mainEntityOfPage": {
-            "@type": "WebPage",
-            "@id": "https://middleton.io/casestudies/case-study-rocketlawyer-mobile.html"
-        },
-        "url": "https://middleton.io/casestudies/case-study-rocketlawyer-mobile.html",
-        "image": "https://middleton.io/images/legal-document-interview.webp",
-        "articleSection": "Case Study",
-        "keywords": ["Product Management", "Mobile Optimization", "Conversion Rate Optimization", "A/B Testing", "Legal Tech", "UX"],
-        "datePublished": "2024-01-01",
-        "dateModified": "2026-04-15"
-    }
-    </script>
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "Mobile Conversion Optimization at Rocket Lawyer",
+  "description": "Failed fast on desktop. Won big on mobile. Drove a 5% conversion lift for Rocket Lawyer's highest-revenue product line through targeted A/B testing.",
+  "author": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  },
+  "publisher": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://middleton.io/casestudies/case-study-rocketlawyer-mobile.html"
+  },
+  "url": "https://middleton.io/casestudies/case-study-rocketlawyer-mobile.html",
+  "image": "https://middleton.io/images/legal-document-interview.webp",
+  "articleSection": "Case Study",
+  "keywords": [
+    "Product Management",
+    "Mobile Optimization",
+    "Conversion Rate Optimization",
+    "A/B Testing",
+    "Legal Tech",
+    "UX"
+  ],
+  "datePublished": "2024-01-01",
+  "dateModified": "2026-04-15"
+}
+</script>
     <!-- Privacy-friendly analytics by Plausible -->
     <script async src="https://plausible.io/js/pa-CycHtdoRKtjDMtDpjBTA4.js"></script>
     <script>

--- a/casestudies/case-study-sendoso.html
+++ b/casestudies/case-study-sendoso.html
@@ -23,34 +23,43 @@
     <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "Article",
-        "headline": "eGift Platform Expansion & Square Partnership at Sendoso",
-        "description": "Scaled catalog coverage, landed strategic partnerships, and built operational infrastructure during a market inflection point.",
-        "author": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        },
-        "publisher": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io"
-        },
-        "mainEntityOfPage": {
-            "@type": "WebPage",
-            "@id": "https://middleton.io/casestudies/case-study-sendoso.html"
-        },
-        "url": "https://middleton.io/casestudies/case-study-sendoso.html",
-        "image": "https://middleton.io/images/sendoso-egift-demo.gif",
-        "articleSection": "Case Study",
-        "keywords": ["Product Management", "Strategic Partnerships", "Global Expansion", "Marketing Tech", "eGifts", "SaaS Platform"],
-        "datePublished": "2024-01-01",
-        "dateModified": "2026-04-15"
-    }
-    </script>
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "eGift Platform Expansion & Square Partnership at Sendoso",
+  "description": "Scaled catalog coverage, landed strategic partnerships, and built operational infrastructure during a market inflection point.",
+  "author": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  },
+  "publisher": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://middleton.io/casestudies/case-study-sendoso.html"
+  },
+  "url": "https://middleton.io/casestudies/case-study-sendoso.html",
+  "image": "https://middleton.io/images/sendoso-egift-demo.gif",
+  "articleSection": "Case Study",
+  "keywords": [
+    "Product Management",
+    "Strategic Partnerships",
+    "Global Expansion",
+    "Marketing Tech",
+    "eGifts",
+    "SaaS Platform"
+  ],
+  "datePublished": "2024-01-01",
+  "dateModified": "2026-04-15"
+}
+</script>
     <!-- Privacy-friendly analytics by Plausible -->
 <script async src="https://plausible.io/js/pa-MRdoFby3N0nkctcj6OWuV.js"></script>
 <script>

--- a/casestudies/index.html
+++ b/casestudies/index.html
@@ -32,69 +32,71 @@
     <!-- Identity verification -->
     <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
     <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
 
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "CollectionPage",
-        "name": "Case Studies | Kevin Middleton",
-        "description": "Selected product case studies from Kevin Middleton covering conversion optimization, 0-to-1 products, enterprise partnerships, and platform modernization.",
-        "url": "https://middleton.io/casestudies/",
-        "image": "https://middleton.io/images/casestudies-featured.png",
-        "author": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "jobTitle": "Full Stack Product Manager",
-            "url": "https://middleton.io",
-            "sameAs": [
-                "https://www.linkedin.com/in/kevinmiddleton",
-                "https://github.com/kevinmmiddleton"
-            ]
-        },
-        "mainEntity": {
-            "@type": "ItemList",
-            "itemListElement": [
-                {
-                    "@type": "ListItem",
-                    "position": 1,
-                    "url": "https://middleton.io/casestudies/case-study-hvac.html",
-                    "name": "Turning Traffic Into Intent — HVAC.com"
-                },
-                {
-                    "@type": "ListItem",
-                    "position": 2,
-                    "url": "https://middleton.io/casestudies/case-study-sendoso.html",
-                    "name": "eGift Platform Expansion & Square Partnership — Sendoso"
-                },
-                {
-                    "@type": "ListItem",
-                    "position": 3,
-                    "url": "https://middleton.io/casestudies/case-study-lever.html",
-                    "name": "HRIS Sync: Moving Lever Upmarket — Lever"
-                },
-                {
-                    "@type": "ListItem",
-                    "position": 4,
-                    "url": "https://middleton.io/casestudies/case-study-rocketlawyer-covea.html",
-                    "name": "Co-Branded Partner Sites — Rocket Lawyer"
-                },
-                {
-                    "@type": "ListItem",
-                    "position": 5,
-                    "url": "https://middleton.io/casestudies/case-study-rocketlawyer-mobile.html",
-                    "name": "Mobile Conversion Optimization — Rocket Lawyer"
-                },
-                {
-                    "@type": "ListItem",
-                    "position": 6,
-                    "url": "https://middleton.io/casestudies/case-study-oracle.html",
-                    "name": "Scaling Social: Platform Overhaul & Network Expansion — Oracle"
-                }
-            ]
-        }
-    }
-    </script>
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "Case Studies | Kevin Middleton",
+  "description": "Selected product case studies from Kevin Middleton covering conversion optimization, 0-to-1 products, enterprise partnerships, and platform modernization.",
+  "url": "https://middleton.io/casestudies/",
+  "image": "https://middleton.io/images/casestudies-featured.png",
+  "author": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "jobTitle": "Full Stack Product Manager",
+    "url": "https://middleton.io",
+    "sameAs": [
+      "https://www.linkedin.com/in/kevinmiddleton",
+      "https://github.com/kevinmmiddleton"
+    ]
+  },
+  "mainEntity": {
+    "@type": "ItemList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "url": "https://middleton.io/casestudies/case-study-hvac.html",
+        "name": "Turning Traffic Into Intent — HVAC.com"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "url": "https://middleton.io/casestudies/case-study-sendoso.html",
+        "name": "eGift Platform Expansion & Square Partnership — Sendoso"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "url": "https://middleton.io/casestudies/case-study-lever.html",
+        "name": "HRIS Sync: Moving Lever Upmarket — Lever"
+      },
+      {
+        "@type": "ListItem",
+        "position": 4,
+        "url": "https://middleton.io/casestudies/case-study-rocketlawyer-covea.html",
+        "name": "Co-Branded Partner Sites — Rocket Lawyer"
+      },
+      {
+        "@type": "ListItem",
+        "position": 5,
+        "url": "https://middleton.io/casestudies/case-study-rocketlawyer-mobile.html",
+        "name": "Mobile Conversion Optimization — Rocket Lawyer"
+      },
+      {
+        "@type": "ListItem",
+        "position": 6,
+        "url": "https://middleton.io/casestudies/case-study-oracle.html",
+        "name": "Scaling Social: Platform Overhaul & Network Expansion — Oracle"
+      }
+    ]
+  }
+}
+</script>
 
     <!-- Privacy-friendly analytics by Plausible -->
     <script async src="https://plausible.io/js/pa-CycHtdoRKtjDMtDpjBTA4.js"></script>

--- a/catdad/index.htm
+++ b/catdad/index.htm
@@ -11,6 +11,7 @@
   <link rel="apple-touch-icon" href="https://middleton.io/catdad/images/sparkles.png">
   <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
   <link rel="me" href="https://github.com/kevinmmiddleton">
+  <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
 
   <!-- Theme color for browser chrome -->
   <meta name="theme-color" content="#FFB7C5" media="(prefers-color-scheme: light)">
@@ -50,14 +51,16 @@
   {
     "@context": "https://schema.org",
     "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
     "name": "Kevin Middleton",
     "jobTitle": "Full Stack Product Manager",
     "url": "https://middleton.io",
     "image": "https://middleton.io/catdad/images/catdad.png",
     "sameAs": [
-      "https://www.linkedin.com/in/kevinmiddleton",
-      "https://github.com/kevinmmiddleton"
-    ],
+                "https://www.linkedin.com/in/kevinmiddleton",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ],
     "address": {
       "@type": "PostalAddress",
       "addressLocality": "New York City",

--- a/fixer/index.htm
+++ b/fixer/index.htm
@@ -9,6 +9,7 @@
   <link rel="canonical" href="https://middleton.io/fixer/">
   <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
   <link rel="me" href="https://github.com/kevinmmiddleton">
+  <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
 
   <!-- Theme Color -->
   <meta name="theme-color" content="#7a5a10" media="(prefers-color-scheme: light)">
@@ -43,46 +44,47 @@
   <link rel="stylesheet" href="fixer.css">
   <!-- Structured Data for SEO -->
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "ProfessionalService",
-    "name": "The Fixer - Product Thinking",
-    "description": "30 minutes of calm, judgment-free product thinking help for product managers and founders who are stuck.",
-    "url": "https://middleton.io/fixer",
-    "provider": {
-      "@type": "Person",
-      "name": "Kevin Middleton",
-      "url": "https://middleton.io",
-      "image": "https://middleton.io/images/profile-picture.jpg",
-      "description": "Full Stack Product Manager with 12+ years of experience building consumer, enterprise, and platform SaaS products.",
-      "sameAs": [
-        "https://www.linkedin.com/in/kevinmiddleton",
-        "https://github.com/kevinmmiddleton"
-      ],
-      "hasOccupation": {
-        "@type": "Occupation",
-        "name": "Full Stack Product Manager",
-        "description": "Product manager who brings structure to ambiguity and helps teams move faster together.",
-        "skills": "Product Strategy, SaaS, A/B Testing, Cross-Functional Leadership"
-      }
-    },
-    "offers": {
-      "@type": "Offer",
-      "price": "0",
-      "priceCurrency": "USD",
-      "availability": "https://schema.org/InStock"
-    },
-    "areaServed": "Worldwide",
-    "potentialAction": {
-      "@type": "ReserveAction",
-      "target": {
-        "@type": "EntryPoint",
-        "urlTemplate": "https://calendly.com/kevin-middleton/let-s-talk"
-      },
-      "name": "Book a call"
+{
+  "@context": "https://schema.org",
+  "@type": "ProfessionalService",
+  "name": "The Fixer - Product Thinking",
+  "description": "30 minutes of calm, judgment-free product thinking help for product managers and founders who are stuck.",
+  "url": "https://middleton.io/fixer",
+  "provider": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "image": "https://middleton.io/images/profile-picture.jpg",
+    "description": "Full Stack Product Manager with 12+ years of experience building consumer, enterprise, and platform SaaS products.",
+    "sameAs": [
+      "https://www.linkedin.com/in/kevinmiddleton",
+      "https://github.com/kevinmmiddleton"
+    ],
+    "hasOccupation": {
+      "@type": "Occupation",
+      "name": "Full Stack Product Manager",
+      "description": "Product manager who brings structure to ambiguity and helps teams move faster together.",
+      "skills": "Product Strategy, SaaS, A/B Testing, Cross-Functional Leadership"
     }
+  },
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD",
+    "availability": "https://schema.org/InStock"
+  },
+  "areaServed": "Worldwide",
+  "potentialAction": {
+    "@type": "ReserveAction",
+    "target": {
+      "@type": "EntryPoint",
+      "urlTemplate": "https://calendly.com/kevin-middleton/let-s-talk"
+    },
+    "name": "Book a call"
   }
-  </script>
+}
+</script>
 
   <!-- Privacy-friendly analytics by Plausible -->
 <script async src="https://plausible.io/js/pa-AXYqKDodwwHKXKB__tJzQ.js"></script>

--- a/index.htm
+++ b/index.htm
@@ -41,11 +41,10 @@
   "image": "https://middleton.io/images/profile-picture.jpg",
   "email": "mailto:kevin@middleton.io",
   "sameAs": [
-    "https://www.linkedin.com/in/kevinmiddleton",
-    "https://github.com/kevinmmiddleton",
-    "https://www.wikidata.org/wiki/Q140389537",
-    "https://calendly.com/kevin-middleton/let-s-talk"
-  ],
+                "https://www.linkedin.com/in/kevinmiddleton",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ],
   "address": {
     "@type": "PostalAddress",
     "addressLocality": "New York",

--- a/kevin/index.html
+++ b/kevin/index.html
@@ -12,47 +12,60 @@
   <link rel="apple-touch-icon" href="https://middleton.io/kevin/images/fire.png">
   <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
   <link rel="me" href="https://github.com/kevinmmiddleton">
+  <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
   <title>KEVIN?! — New York's Hottest Product Manager</title>
 
   <!-- JSON-LD Structured Data -->
   <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "WebPage",
-    "name": "KEVIN?! — New York's Hottest Product Manager",
-    "url": "https://middleton.io/kevin",
-    "description": "New York City's hottest product manager. 12 years across consumer, enterprise, and platform. This place has everything.",
-    "about": {
-      "@type": "Person",
-      "name": "Kevin Middleton",
-      "url": "https://middleton.io",
-      "sameAs": [
-        "https://www.linkedin.com/in/kevinmiddleton",
-        "https://github.com/kevinmmiddleton"
-      ],
-      "description": "Full Stack Product Manager with 12 years of experience across consumer, enterprise, and platform. Builds systems that help product teams not lose their minds.",
-      "hasOccupation": {
-        "@type": "Occupation",
-        "name": "Full Stack Product Manager",
-        "occupationalCategory": "15-1199.09",
-        "description": "Builds systems that help product teams not lose their minds. 12 years across consumer, enterprise, and platform products.",
-        "experienceRequirements": "12 years",
-        "skills": ["Product Strategy", "Consumer Products", "Enterprise Products", "Platform Products", "Team Leadership"]
-      },
-      "jobTitle": "Full Stack Product Manager",
-      "knowsAbout": ["Product Management", "Consumer Products", "Enterprise Products", "Platform Products"],
-      "workLocation": {
-        "@type": "Place",
-        "address": {
-          "@type": "PostalAddress",
-          "addressLocality": "New York",
-          "addressRegion": "NY",
-          "addressCountry": "US"
-        }
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "KEVIN?! — New York's Hottest Product Manager",
+  "url": "https://middleton.io/kevin",
+  "description": "New York City's hottest product manager. 12 years across consumer, enterprise, and platform. This place has everything.",
+  "about": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": [
+      "https://www.linkedin.com/in/kevinmiddleton",
+      "https://github.com/kevinmmiddleton"
+    ],
+    "description": "Full Stack Product Manager with 12 years of experience across consumer, enterprise, and platform. Builds systems that help product teams not lose their minds.",
+    "hasOccupation": {
+      "@type": "Occupation",
+      "name": "Full Stack Product Manager",
+      "occupationalCategory": "15-1199.09",
+      "description": "Builds systems that help product teams not lose their minds. 12 years across consumer, enterprise, and platform products.",
+      "experienceRequirements": "12 years",
+      "skills": [
+        "Product Strategy",
+        "Consumer Products",
+        "Enterprise Products",
+        "Platform Products",
+        "Team Leadership"
+      ]
+    },
+    "jobTitle": "Full Stack Product Manager",
+    "knowsAbout": [
+      "Product Management",
+      "Consumer Products",
+      "Enterprise Products",
+      "Platform Products"
+    ],
+    "workLocation": {
+      "@type": "Place",
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "New York",
+        "addressRegion": "NY",
+        "addressCountry": "US"
       }
     }
   }
-  </script>
+}
+</script>
 
   <!-- Open Graph -->
   <meta property="og:type" content="website" />

--- a/kevinos/index.html
+++ b/kevinos/index.html
@@ -11,6 +11,7 @@
     <link rel="apple-touch-icon" href="https://middleton.io/kevinos/images/alien-monster.png">
     <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
     <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
     <!-- Theme color for browser chrome -->
     <meta name="theme-color" content="#f0f0f5" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0a0a0f" media="(prefers-color-scheme: dark)">
@@ -42,15 +43,17 @@
     {
         "@context": "https://schema.org",
         "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
         "name": "Kevin Middleton",
         "url": "https://middleton.io",
         "image": "https://middleton.io/images/profile-picture.jpg",
         "description": "Full Stack Product Manager with 12+ years of experience building consumer, enterprise, and platform SaaS products. I bring structure to ambiguity and help teams move faster together.",
         "jobTitle": "Full Stack Product Manager",
         "sameAs": [
-            "https://www.linkedin.com/in/kevinmiddleton",
-            "https://github.com/kevinmmiddleton"
-        ],
+                "https://www.linkedin.com/in/kevinmiddleton",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ],
         "address": {
             "@type": "PostalAddress",
             "addressLocality": "New York",

--- a/llms.txt
+++ b/llms.txt
@@ -2,6 +2,19 @@
 
 > Full Stack Product Manager building platforms, internal tools, and AI workflows that connect teams and systems. 12+ years across consumer, enterprise, and platform SaaS. Currently open to product leadership roles.
 
+
+## Identity
+
+The same person across the web. Wikidata is the canonical, disambiguating entity —
+there is more than one Kevin Middleton, and Q140389537 is this one.
+
+- [Wikidata: Q140389537](https://www.wikidata.org/wiki/Q140389537): canonical entity record.
+- [LinkedIn](https://www.linkedin.com/in/kevinmiddleton/): professional profile and recommendations.
+- [GitHub](https://github.com/kevinmmiddleton): open-source work, including Claude plugins.
+
+Structured data on the site declares this person once, as
+`https://middleton.io/#kevin`, and every page references that same `@id`.
+
 ## About
 
 - [About Kevin](https://middleton.io/#about): Background, philosophy, and how he works as a "full-stack" PM across people, process, and product.

--- a/nyc/index.htm
+++ b/nyc/index.htm
@@ -13,6 +13,7 @@
   <link rel="apple-touch-icon" href="https://middleton.io/nyc/images/statue-of-liberty.png">
   <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
   <link rel="me" href="https://github.com/kevinmmiddleton">
+  <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
   <meta name="theme-color" content="#f4f4f7" media="(prefers-color-scheme: light)">
   <meta name="theme-color" content="#0f1115" media="(prefers-color-scheme: dark)">
 
@@ -59,24 +60,25 @@
           "name": "Kevin Middleton"
         },
         "about": {
-          "@id": "https://middleton.io/nyc#person"
+          "@id": "https://middleton.io/#kevin"
         },
         "mainEntity": {
-          "@id": "https://middleton.io/nyc#person"
+          "@id": "https://middleton.io/#kevin"
         }
       },
       {
         "@type": "Person",
-        "@id": "https://middleton.io/nyc#person",
+        "@id": "https://middleton.io/#kevin",
         "name": "Kevin Middleton",
         "jobTitle": "Full Stack Product Manager",
         "url": "https://middleton.io",
         "image": "https://middleton.io/images/profile-picture.jpg",
         "description": "Full Stack Product Manager with 12+ years of experience building consumer, enterprise, and platform SaaS products. I bring calm to chaotic systems and partner closely with engineering and design.",
         "sameAs": [
-          "https://www.linkedin.com/in/kevinmiddleton",
-          "https://github.com/kevinmmiddleton"
-        ],
+                "https://www.linkedin.com/in/kevinmiddleton",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ],
         "alumniOf": {
           "@type": "CollegeOrUniversity",
           "name": "Virginia Tech"

--- a/officehours/index.htm
+++ b/officehours/index.htm
@@ -16,6 +16,8 @@
   <!-- LinkedIn Profile -->
   <meta property="profile:username" content="kevinmiddleton" />
   <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/" />
+  <link rel="me" href="https://github.com/kevinmmiddleton">
+  <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
 
   <!-- Open Graph -->
   <meta property="og:type" content="website" />
@@ -51,14 +53,15 @@
     "@graph": [
       {
         "@type": "Person",
-        "@id": "https://middleton.io/#person",
+        "@id": "https://middleton.io/#kevin",
         "name": "Kevin Middleton",
         "jobTitle": "Full Stack Product Manager",
         "url": "https://middleton.io/",
         "sameAs": [
-          "https://www.linkedin.com/in/kevinmiddleton",
-          "https://github.com/kevinmmiddleton"
-        ]
+                "https://www.linkedin.com/in/kevinmiddleton",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ]
       },
       {
         "@type": "Service",
@@ -66,7 +69,7 @@
         "name": "Office Hours",
         "description": "Free 30-minute product coaching sessions. Bring a messy problem—scope creep, stakeholder confusion, prioritization paralysis—and leave with a clearer head.",
         "url": "https://middleton.io/officehours/",
-        "provider": { "@id": "https://middleton.io/#person" },
+        "provider": { "@id": "https://middleton.io/#kevin" },
         "serviceType": "Product Coaching",
         "isAccessibleForFree": true,
         "offers": {

--- a/okf/index.md
+++ b/okf/index.md
@@ -11,6 +11,17 @@ timestamp: 2026-06-30
 
 This is an [Open Knowledge Format (OKF)](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing) bundle: a directory of Markdown files, each describing one concept, written for AI agents and other automated readers.
 
+
+## Identity
+
+- Wikidata (canonical entity): https://www.wikidata.org/wiki/Q140389537
+- LinkedIn: https://www.linkedin.com/in/kevinmiddleton/
+- GitHub: https://github.com/kevinmmiddleton
+
+There is more than one Kevin Middleton. Q140389537 is this one. The site's
+structured data declares him once as `https://middleton.io/#kevin`; every page
+references that same `@id`.
+
 Source of truth for this content is the website at https://middleton.io. Files in this bundle:
 
 - [`profile.md`](profile.md): who Kevin is, role, location, links

--- a/prototypes/amex/index.html
+++ b/prototypes/amex/index.html
@@ -819,35 +819,37 @@ body { font-family: 'Inter', -apple-system, sans-serif; color: var(--dark); back
 </style>
     <!-- JSON-LD -->
     <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "CreativeWork",
-        "name": "Resy × AI Agents: From Customer Journey to MCP Server",
-        "description": "Resy x AI Agents: A prototype exploring how MCP servers can power AI-driven dining experiences at American Express.",
-        "url": "https://middleton.io/prototypes/amex/",
-        "author": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        },
-        "isPartOf": {
-            "@type": "WebSite",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io"
-        },
-        "mainEntityOfPage": {
-            "@type": "WebPage",
-            "@id": "https://middleton.io/prototypes/amex/"
-        },
-        "creator": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        }
-    }
-    </script>
+{
+  "@context": "https://schema.org",
+  "@type": "CreativeWork",
+  "name": "Resy × AI Agents: From Customer Journey to MCP Server",
+  "description": "Resy x AI Agents: A prototype exploring how MCP servers can power AI-driven dining experiences at American Express.",
+  "url": "https://middleton.io/prototypes/amex/",
+  "author": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://middleton.io/prototypes/amex/"
+  },
+  "creator": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  }
+}
+</script>
 </head>
 <body>
 

--- a/prototypes/baldor/index.html
+++ b/prototypes/baldor/index.html
@@ -22,35 +22,37 @@
     </style>
     <!-- JSON-LD -->
     <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "CreativeWork",
-        "name": "Baldor Growth Experiments",
-        "description": "Baldor Growth Experiments: Product-led growth concepts for Baldor Specialty Foods, exploring new acquisition and engagement channels.",
-        "url": "https://middleton.io/prototypes/baldor/",
-        "author": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        },
-        "isPartOf": {
-            "@type": "WebSite",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io"
-        },
-        "mainEntityOfPage": {
-            "@type": "WebPage",
-            "@id": "https://middleton.io/prototypes/baldor/"
-        },
-        "creator": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        }
-    }
-    </script>
+{
+  "@context": "https://schema.org",
+  "@type": "CreativeWork",
+  "name": "Baldor Growth Experiments",
+  "description": "Baldor Growth Experiments: Product-led growth concepts for Baldor Specialty Foods, exploring new acquisition and engagement channels.",
+  "url": "https://middleton.io/prototypes/baldor/",
+  "author": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://middleton.io/prototypes/baldor/"
+  },
+  "creator": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  }
+}
+</script>
 </head>
 <body>
     <div id="root"></div>

--- a/prototypes/hvac/index.html
+++ b/prototypes/hvac/index.html
@@ -673,35 +673,37 @@
     </style>
     <!-- JSON-LD -->
     <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "CreativeWork",
-        "name": "HVAC.com Product Challenge",
-        "description": "HVAC.com Product Challenge: UX and product concepts to improve the homeowner-to-contractor matching experience.",
-        "url": "https://middleton.io/prototypes/hvac/",
-        "author": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        },
-        "isPartOf": {
-            "@type": "WebSite",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io"
-        },
-        "mainEntityOfPage": {
-            "@type": "WebPage",
-            "@id": "https://middleton.io/prototypes/hvac/"
-        },
-        "creator": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        }
-    }
-    </script>
+{
+  "@context": "https://schema.org",
+  "@type": "CreativeWork",
+  "name": "HVAC.com Product Challenge",
+  "description": "HVAC.com Product Challenge: UX and product concepts to improve the homeowner-to-contractor matching experience.",
+  "url": "https://middleton.io/prototypes/hvac/",
+  "author": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://middleton.io/prototypes/hvac/"
+  },
+  "creator": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  }
+}
+</script>
 </head>
 <body>
 

--- a/prototypes/index.html
+++ b/prototypes/index.html
@@ -19,26 +19,27 @@
 <link rel="stylesheet" href="/fv.css?v=b7966cd1">
 <script type="application/ld+json">
 {
-    "@context": "https://schema.org",
-    "@type": "CollectionPage",
-    "name": "Prototypes",
-    "description": "Interactive product prototypes by Kevin Middleton, concept explorations for Resy, Baldor, HVAC.com, and more.",
-    "url": "https://middleton.io/prototypes/",
-    "author": {
-        "@type": "Person",
-        "name": "Kevin Middleton",
-        "url": "https://middleton.io",
-        "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-    },
-    "isPartOf": {
-        "@type": "WebSite",
-        "name": "Kevin Middleton",
-        "url": "https://middleton.io"
-    },
-    "mainEntityOfPage": {
-        "@type": "WebPage",
-        "@id": "https://middleton.io/prototypes/"
-    }
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "Prototypes",
+  "description": "Interactive product prototypes by Kevin Middleton, concept explorations for Resy, Baldor, HVAC.com, and more.",
+  "url": "https://middleton.io/prototypes/",
+  "author": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://middleton.io/prototypes/"
+  }
 }
 </script>
 <script async src="https://plausible.io/js/pa-CycHtdoRKtjDMtDpjBTA4.js"></script>

--- a/prototypes/sa/index.html
+++ b/prototypes/sa/index.html
@@ -1525,35 +1525,37 @@ body { font-family: 'Inter', -apple-system, sans-serif; color: var(--sa-dark); b
 </style>
     <!-- JSON-LD -->
     <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "CreativeWork",
-        "name": "SA Website Improvement Concepts",
-        "description": "Success Academy Website Improvement Concepts: Product thinking applied to modernize and improve a school network's web presence.",
-        "url": "https://middleton.io/prototypes/sa/",
-        "author": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        },
-        "isPartOf": {
-            "@type": "WebSite",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io"
-        },
-        "mainEntityOfPage": {
-            "@type": "WebPage",
-            "@id": "https://middleton.io/prototypes/sa/"
-        },
-        "creator": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        }
-    }
-    </script>
+{
+  "@context": "https://schema.org",
+  "@type": "CreativeWork",
+  "name": "SA Website Improvement Concepts",
+  "description": "Success Academy Website Improvement Concepts: Product thinking applied to modernize and improve a school network's web presence.",
+  "url": "https://middleton.io/prototypes/sa/",
+  "author": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://middleton.io/prototypes/sa/"
+  },
+  "creator": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  }
+}
+</script>
 </head>
 <body>
 

--- a/recipes/index.html
+++ b/recipes/index.html
@@ -109,12 +109,14 @@
   {
     "@context": "https://schema.org",
     "@type": "Person",
+            "@id": "https://middleton.io/#kevin",
     "name": "Kevin Middleton",
     "url": "https://middleton.io",
     "sameAs": [
-      "https://www.linkedin.com/in/kevinmiddleton",
-      "https://github.com/kevinmmiddleton"
-    ],
+                "https://www.linkedin.com/in/kevinmiddleton",
+                "https://github.com/kevinmmiddleton",
+                "https://www.wikidata.org/wiki/Q140389537"
+            ],
     "description": "Product manager by day, home cook by night. I make complex work feel simple.",
     "jobTitle": "Full Stack Product Manager",
     "hasOccupation": {

--- a/slides/amex/index.html
+++ b/slides/amex/index.html
@@ -48,35 +48,37 @@
 </script>
     <!-- JSON-LD -->
     <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "PresentationDigitalDocument",
-        "name": "American Express: Agentic MCP Prototype",
-        "description": "Three rounds for an Amex Digital Labs PM role. I built a live prototype between rounds. The role got paused. Here's the work.",
-        "url": "https://middleton.io/slides/amex/",
-        "author": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        },
-        "isPartOf": {
-            "@type": "WebSite",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io"
-        },
-        "mainEntityOfPage": {
-            "@type": "WebPage",
-            "@id": "https://middleton.io/slides/amex/"
-        },
-        "creator": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        }
-    }
-    </script>
+{
+  "@context": "https://schema.org",
+  "@type": "PresentationDigitalDocument",
+  "name": "American Express: Agentic MCP Prototype",
+  "description": "Three rounds for an Amex Digital Labs PM role. I built a live prototype between rounds. The role got paused. Here's the work.",
+  "url": "https://middleton.io/slides/amex/",
+  "author": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://middleton.io/slides/amex/"
+  },
+  "creator": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  }
+}
+</script>
 </head>
 <body>
 

--- a/slides/applause/index.html
+++ b/slides/applause/index.html
@@ -48,35 +48,37 @@
 </script>
     <!-- JSON-LD -->
     <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "PresentationDigitalDocument",
-        "name": "Applause: When the Interview Is Just Free Consulting",
-        "description": "A 45-minute interview that turned into a live strategy session on the company's real product. I gave the work. They ghosted. A cautionary tale.",
-        "url": "https://middleton.io/slides/applause/",
-        "author": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        },
-        "isPartOf": {
-            "@type": "WebSite",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io"
-        },
-        "mainEntityOfPage": {
-            "@type": "WebPage",
-            "@id": "https://middleton.io/slides/applause/"
-        },
-        "creator": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        }
-    }
-    </script>
+{
+  "@context": "https://schema.org",
+  "@type": "PresentationDigitalDocument",
+  "name": "Applause: When the Interview Is Just Free Consulting",
+  "description": "A 45-minute interview that turned into a live strategy session on the company's real product. I gave the work. They ghosted. A cautionary tale.",
+  "url": "https://middleton.io/slides/applause/",
+  "author": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://middleton.io/slides/applause/"
+  },
+  "creator": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  }
+}
+</script>
 </head>
 <body>
 

--- a/slides/gong/index.html
+++ b/slides/gong/index.html
@@ -48,35 +48,37 @@
 </script>
     <!-- JSON-LD -->
     <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "PresentationDigitalDocument",
-        "name": "Gong: WhatsApp vs. Slack Connect Panel",
-        "description": "Real panel exercise for Gong's Senior PM, International & Enterprise role. Prompt, research, the actual decks, and what I'd change.",
-        "url": "https://middleton.io/slides/gong/",
-        "author": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        },
-        "isPartOf": {
-            "@type": "WebSite",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io"
-        },
-        "mainEntityOfPage": {
-            "@type": "WebPage",
-            "@id": "https://middleton.io/slides/gong/"
-        },
-        "creator": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        }
-    }
-    </script>
+{
+  "@context": "https://schema.org",
+  "@type": "PresentationDigitalDocument",
+  "name": "Gong: WhatsApp vs. Slack Connect Panel",
+  "description": "Real panel exercise for Gong's Senior PM, International & Enterprise role. Prompt, research, the actual decks, and what I'd change.",
+  "url": "https://middleton.io/slides/gong/",
+  "author": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://middleton.io/slides/gong/"
+  },
+  "creator": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  }
+}
+</script>
 </head>
 <body>
 

--- a/slides/hvac/index.html
+++ b/slides/hvac/index.html
@@ -48,35 +48,37 @@
 </script>
     <!-- JSON-LD -->
     <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "PresentationDigitalDocument",
-        "name": "HVAC.com: The Take-Home That Got the Yes",
-        "description": "How I got the Senior PM role at HVAC.com. The take-home brief, five rounds, a full-day onsite, the offer pressure, and what I'd change next time.",
-        "url": "https://middleton.io/slides/hvac/",
-        "author": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        },
-        "isPartOf": {
-            "@type": "WebSite",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io"
-        },
-        "mainEntityOfPage": {
-            "@type": "WebPage",
-            "@id": "https://middleton.io/slides/hvac/"
-        },
-        "creator": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        }
-    }
-    </script>
+{
+  "@context": "https://schema.org",
+  "@type": "PresentationDigitalDocument",
+  "name": "HVAC.com: The Take-Home That Got the Yes",
+  "description": "How I got the Senior PM role at HVAC.com. The take-home brief, five rounds, a full-day onsite, the offer pressure, and what I'd change next time.",
+  "url": "https://middleton.io/slides/hvac/",
+  "author": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://middleton.io/slides/hvac/"
+  },
+  "creator": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  }
+}
+</script>
 </head>
 <body>
 

--- a/slides/index.html
+++ b/slides/index.html
@@ -38,29 +38,30 @@
 </script>
     <!-- JSON-LD -->
     <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "CollectionPage",
-        "name": "Slides I Made for Free",
-        "description": "Real interview presentations, with the prompt, the work, the outcome, and what I'd do differently. Free to read, free to download.",
-        "url": "https://middleton.io/slides/",
-        "author": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        },
-        "isPartOf": {
-            "@type": "WebSite",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io"
-        },
-        "mainEntityOfPage": {
-            "@type": "WebPage",
-            "@id": "https://middleton.io/slides/"
-        }
-    }
-    </script>
+{
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "name": "Slides I Made for Free",
+  "description": "Real interview presentations, with the prompt, the work, the outcome, and what I'd do differently. Free to read, free to download.",
+  "url": "https://middleton.io/slides/",
+  "author": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://middleton.io/slides/"
+  }
+}
+</script>
     <!-- Identity verification: same three profiles the homepage claims, so every
          page resolves to one entity rather than a separate author blob. -->
     <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">

--- a/slides/justworks/index.html
+++ b/slides/justworks/index.html
@@ -48,35 +48,37 @@
 </script>
     <!-- JSON-LD -->
     <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "PresentationDigitalDocument",
-        "name": "Justworks: Wage Garnishment Case Study",
-        "description": "Take-home case study and onsite workshop for Justworks Senior PM, PayTax. Centerpiece is a real user interview with a small business owner in Virginia.",
-        "url": "https://middleton.io/slides/justworks/",
-        "author": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        },
-        "isPartOf": {
-            "@type": "WebSite",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io"
-        },
-        "mainEntityOfPage": {
-            "@type": "WebPage",
-            "@id": "https://middleton.io/slides/justworks/"
-        },
-        "creator": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        }
-    }
-    </script>
+{
+  "@context": "https://schema.org",
+  "@type": "PresentationDigitalDocument",
+  "name": "Justworks: Wage Garnishment Case Study",
+  "description": "Take-home case study and onsite workshop for Justworks Senior PM, PayTax. Centerpiece is a real user interview with a small business owner in Virginia.",
+  "url": "https://middleton.io/slides/justworks/",
+  "author": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://middleton.io/slides/justworks/"
+  },
+  "creator": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  }
+}
+</script>
 </head>
 <body>
 

--- a/slides/red-ventures/index.html
+++ b/slides/red-ventures/index.html
@@ -48,35 +48,37 @@
 </script>
     <!-- JSON-LD -->
     <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "PresentationDigitalDocument",
-        "name": "Red Ventures: When \"Hypothetical\" Was a Live Marketplace",
-        "description": "A take-home for a Red Ventures PM role. The 'hypothetical' case was one of their actual brands. I sent the work, then asked them not to use it.",
-        "url": "https://middleton.io/slides/red-ventures/",
-        "author": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        },
-        "isPartOf": {
-            "@type": "WebSite",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io"
-        },
-        "mainEntityOfPage": {
-            "@type": "WebPage",
-            "@id": "https://middleton.io/slides/red-ventures/"
-        },
-        "creator": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        }
-    }
-    </script>
+{
+  "@context": "https://schema.org",
+  "@type": "PresentationDigitalDocument",
+  "name": "Red Ventures: When \"Hypothetical\" Was a Live Marketplace",
+  "description": "A take-home for a Red Ventures PM role. The 'hypothetical' case was one of their actual brands. I sent the work, then asked them not to use it.",
+  "url": "https://middleton.io/slides/red-ventures/",
+  "author": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://middleton.io/slides/red-ventures/"
+  },
+  "creator": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  }
+}
+</script>
 </head>
 <body>
 

--- a/slides/success-academy/index.html
+++ b/slides/success-academy/index.html
@@ -48,35 +48,37 @@
 </script>
     <!-- JSON-LD -->
     <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "PresentationDigitalDocument",
-        "name": "Success Academy: PM for Family Apps and Public Web",
-        "description": "Five rounds for a Product Manager role at Success Academy. Prototype, onsite panel, final with the CTO. Did not advance. Here's the work and the feedback exchange.",
-        "url": "https://middleton.io/slides/success-academy/",
-        "author": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        },
-        "isPartOf": {
-            "@type": "WebSite",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io"
-        },
-        "mainEntityOfPage": {
-            "@type": "WebPage",
-            "@id": "https://middleton.io/slides/success-academy/"
-        },
-        "creator": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        }
-    }
-    </script>
+{
+  "@context": "https://schema.org",
+  "@type": "PresentationDigitalDocument",
+  "name": "Success Academy: PM for Family Apps and Public Web",
+  "description": "Five rounds for a Product Manager role at Success Academy. Prototype, onsite panel, final with the CTO. Did not advance. Here's the work and the feedback exchange.",
+  "url": "https://middleton.io/slides/success-academy/",
+  "author": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  },
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://middleton.io/slides/success-academy/"
+  },
+  "creator": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  }
+}
+</script>
 </head>
 <body>
 

--- a/tools/blog-generate.mjs
+++ b/tools/blog-generate.mjs
@@ -167,7 +167,13 @@ const HEAD_LINKS = `    <!-- One stylesheet for the whole site. No webfont reque
     <link rel="stylesheet" href="/fv.css?v=b7966cd1">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">`;
+    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+    <!-- Identity verification. Same three profiles the homepage claims, so every
+         page resolves to one entity rather than a separate author blob.
+         Wikidata is the disambiguating anchor. -->
+    <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
+    <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">`;
 const PLAUSIBLE = `    <!-- Privacy-friendly analytics by Plausible -->
     <script async src="https://plausible.io/js/pa-CycHtdoRKtjDMtDpjBTA4.js"></script>
     <script>
@@ -214,8 +220,8 @@ function articlePage(post, all) {
   const article = {
     "@context":"https://schema.org","@type":"Article",
     headline: post.title, description: post.excerpt,
-    author:{"@type":"Person",name:"Kevin Middleton",url:SITE,sameAs:"https://www.linkedin.com/in/kevinmiddleton"},
-    publisher:{"@type":"Person",name:"Kevin Middleton",url:SITE},
+    author:{"@type":"Person","@id":"https://middleton.io/#kevin",name:"Kevin Middleton",url:SITE,sameAs:["https://www.linkedin.com/in/kevinmiddleton/","https://github.com/kevinmmiddleton","https://www.wikidata.org/wiki/Q140389537"]},
+    publisher:{"@type":"Person","@id":"https://middleton.io/#kevin",name:"Kevin Middleton",url:SITE},
     mainEntityOfPage:{"@type":"WebPage","@id":url}, url, image: coverAbs,
     articleSection:"Blog", keywords: post.tags||[],
     wordCount: (post.body_markdown||'').split(/\s+/).filter(Boolean).length,
@@ -312,7 +318,7 @@ ${LIGHTBOX}
 function hubPage(posts) {
   const blogLd = {
     "@context":"https://schema.org","@type":"Blog",name:"Kevin Middleton's Blog",url:`${SITE}/blog/`,
-    author:{"@type":"Person",name:"Kevin Middleton",url:SITE},
+    author:{"@type":"Person","@id":"https://middleton.io/#kevin",name:"Kevin Middleton",url:SITE},
     blogPost: posts.map(p=>({"@type":"BlogPosting",headline:p.title,url:`${SITE}/blog/${p.slug}/`,datePublished:isoDate(p.published_at)}))};
   const crumbs = {"@context":"https://schema.org","@type":"BreadcrumbList",itemListElement:[
     {"@type":"ListItem",position:1,name:"Home",item:`${SITE}/`},

--- a/visionbort/index.html
+++ b/visionbort/index.html
@@ -6,6 +6,11 @@
   <title>Visionbort — Create Your Vision Board</title>
   <meta name="description" content="Create vision boards that inspire you. Drag, draw, and arrange your dreams.">
   <link rel="canonical" href="https://middleton.io/visionbort/">
+    <!-- Identity verification: same profiles the homepage claims, so this page
+         resolves to one entity. Wikidata is the disambiguating anchor. -->
+    <link rel="me" href="https://www.linkedin.com/in/kevinmiddleton/">
+    <link rel="me" href="https://github.com/kevinmmiddleton">
+    <link rel="me" href="https://www.wikidata.org/wiki/Q140389537">
   <meta property="og:type" content="website">
   <meta property="og:title" content="Visionbort — Create Your Vision Board">
   <meta property="og:description" content="Create vision boards that inspire you. Drag, draw, and arrange your dreams.">
@@ -22,31 +27,32 @@
   <script src="https://cdn.jsdelivr.net/npm/html-to-image@1.11.11/dist/html-to-image.js" defer></script>
     <!-- JSON-LD -->
     <script type="application/ld+json">
-    {
-        "@context": "https://schema.org",
-        "@type": "WebApplication",
-        "name": "Visionbort",
-        "description": "Create vision boards that inspire you. Drag, draw, and arrange your dreams.",
-        "url": "https://middleton.io/visionbort/",
-        "isPartOf": {
-            "@type": "WebSite",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io"
-        },
-        "mainEntityOfPage": {
-            "@type": "WebPage",
-            "@id": "https://middleton.io/visionbort/"
-        },
-        "creator": {
-            "@type": "Person",
-            "name": "Kevin Middleton",
-            "url": "https://middleton.io",
-            "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
-        },
-        "applicationCategory": "DesignApplication",
-        "operatingSystem": "Web"
-    }
-    </script>
+{
+  "@context": "https://schema.org",
+  "@type": "WebApplication",
+  "name": "Visionbort",
+  "description": "Create vision boards that inspire you. Drag, draw, and arrange your dreams.",
+  "url": "https://middleton.io/visionbort/",
+  "isPartOf": {
+    "@type": "WebSite",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": "https://middleton.io/visionbort/"
+  },
+  "creator": {
+    "@type": "Person",
+    "@id": "https://middleton.io/#kevin",
+    "name": "Kevin Middleton",
+    "url": "https://middleton.io",
+    "sameAs": "https://www.linkedin.com/in/kevinmiddleton"
+  },
+  "applicationCategory": "DesignApplication",
+  "operatingSystem": "Web"
+}
+</script>
 </head>
 <body>
   <!-- Welcome Modal -->


### PR DESCRIPTION
The site declared Kevin as up to **four different people**. Name and job title were already consistent everywhere — the `@id` was not.

| Before | After |
|---|---|
| `@id` values: `#kevin`, `#person`, `/nyc#person`, and none | **one**: `https://middleton.io/#kevin` on 45 pages |
| 60 anonymous `Person` nodes across 39 pages (author / publisher / creator) | **0** |
| Wikidata Q140389537 on 10 of 58 pages | **34**, including all 16 blog pages |
| `llms.txt` / `okf/index.md` identity anchors | Identity section in both, Wikidata named canonical |
| Calendly in `sameAs` | removed |

Office hours was also missing GitHub from `rel=me`; visionbort had no `rel=me` at all. Both fixed.

The blog changes go through the generator template, so the daily cron preserves them — verified idempotent.

Checked: 0 invalid JSON-LD blocks, 340 internal links with none broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)