### PR TITLE
SEO: tighten meta descriptions

### DIFF
--- a/blog/_posts/product-management-is-under-attack.md
+++ b/blog/_posts/product-management-is-under-attack.md
@@ -14,7 +14,7 @@ tags:
   - Career
 featured: false
 sort_order: null
-excerpt: We keep killing product management. It keeps coming back.
+excerpt: We keep killing product management. It keeps coming back. What the latest round of obituaries gets wrong about the work, and who actually does it.
 cover_image: /blog/images/product-management-is-dead-cover.png
 cover_alt: A cartoon gravestone reading "R.I.P. Product Management" with a hand clawing its way up out of the dirt in front of it, suggesting the role is declared dead but coming back to life.
 linkedin_url: ''

--- a/blog/feed.xml
+++ b/blog/feed.xml
@@ -12,7 +12,7 @@
       <link>https://middleton.io/blog/product-management-is-dead/</link>
       <guid isPermaLink="true">https://middleton.io/blog/product-management-is-dead/</guid>
       <pubDate>Thu, 23 Jul 2026 00:00:00 GMT</pubDate>
-      <description>We keep killing product management. It keeps coming back.</description>
+      <description>We keep killing product management. It keeps coming back. What the latest round of obituaries gets wrong about the work, and who actually does it.</description>
       <enclosure url="https://middleton.io/blog/images/product-management-is-dead-cover.png" type="image/png" length="2276549"/>
       <media:content url="https://middleton.io/blog/images/product-management-is-dead-cover.png" medium="image" type="image/png"/>
       <media:thumbnail url="https://middleton.io/blog/images/product-management-is-dead-cover.png"/>

--- a/blog/index.html
+++ b/blog/index.html
@@ -208,7 +208,7 @@
                 <div class="post-card__body">
                     <p class="post-eyebrow">Product</p>
                     <h2>Product Management is dead. Long live Product Management.</h2>
-                    <p>We keep killing product management. It keeps coming back.</p>
+                    <p>We keep killing product management. It keeps coming back. What the latest round of obituaries gets wrong about the work, and who actually does it.</p>
                     <span class="post-date">July 23, 2026</span>
                 </div>
             </a>

--- a/blog/product-management-is-dead/index.html
+++ b/blog/product-management-is-dead/index.html
@@ -6,7 +6,7 @@
     <meta name="theme-color" content="#F4F4F5" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0F0F12" media="(prefers-color-scheme: dark)">
     <title>Product Management is dead. Long live Product Management. | Kevin Middleton</title>
-    <meta name="description" content="We keep killing product management. It keeps coming back.">
+    <meta name="description" content="We keep killing product management. It keeps coming back. What the latest round of obituaries gets wrong about the work, and who actually does it.">
 
     <link rel="canonical" href="https://middleton.io/blog/product-management-is-dead/">
     <link rel="alternate" type="application/rss+xml" title="Kevin Middleton" href="https://middleton.io/blog/feed.xml">
@@ -15,7 +15,7 @@
     <meta property="og:type" content="article">
     <meta property="og:url" content="https://middleton.io/blog/product-management-is-dead/">
     <meta property="og:title" content="Product Management is dead. Long live Product Management.">
-    <meta property="og:description" content="We keep killing product management. It keeps coming back.">
+    <meta property="og:description" content="We keep killing product management. It keeps coming back. What the latest round of obituaries gets wrong about the work, and who actually does it.">
     <meta property="og:image" content="https://middleton.io/blog/images/product-management-is-dead-cover.png">
     <meta property="og:site_name" content="Kevin Middleton">
     <meta property="article:published_time" content="2026-07-23">
@@ -24,7 +24,7 @@
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Product Management is dead. Long live Product Management.">
-    <meta name="twitter:description" content="We keep killing product management. It keeps coming back.">
+    <meta name="twitter:description" content="We keep killing product management. It keeps coming back. What the latest round of obituaries gets wrong about the work, and who actually does it.">
     <meta name="twitter:image" content="https://middleton.io/blog/images/product-management-is-dead-cover.png">
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
@@ -46,7 +46,7 @@
         "@context": "https://schema.org",
         "@type": "Article",
         "headline": "Product Management is dead. Long live Product Management.",
-        "description": "We keep killing product management. It keeps coming back.",
+        "description": "We keep killing product management. It keeps coming back. What the latest round of obituaries gets wrong about the work, and who actually does it.",
         "author": {
             "@type": "Person",
             "@id": "https://middleton.io/#kevin",

--- a/index.htm
+++ b/index.htm
@@ -11,7 +11,7 @@
 <!-- descriptions lead with "Full Stack Product Manager" rather than the live
      site's "Senior Product Manager and full-stack PM", to match the identity
      the rest of this build standardised on (title, header, hero arc line). -->
-<meta name="description" content="Kevin Middleton is a Full Stack Product Manager with 12+ years building platforms, internal tools, and AI-driven workflows for enterprise and consumer SaaS products.">
+<meta name="description" content="Kevin Middleton, Full Stack Product Manager. 12+ years building platforms, internal tools, and AI workflows for enterprise and consumer SaaS.">
 <link rel="canonical" href="https://middleton.io/">
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/kevin/index.html
+++ b/kevin/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#f4f4f7" media="(prefers-color-scheme: light)">
   <meta name="theme-color" content="#1a1c2e" media="(prefers-color-scheme: dark)">
-  <meta name="description" content="New York City's hottest product manager. 12 years across consumer, enterprise, and platform. This place has everything: spreadsheets that feel like violence, human Jira boards, and the quiet confidence of a man who sourced $1.4M before he was even hired.">
+  <meta name="description" content="New York City's hottest product manager. This place has everything: spreadsheets that feel like violence, three cats, and a human Jira board.">
   <link rel="canonical" href="https://middleton.io/kevin/">
   <link rel="icon" type="image/png" href="https://middleton.io/kevin/images/fire.png">
   <link rel="apple-touch-icon" href="https://middleton.io/kevin/images/fire.png">

--- a/kevinos/index.html
+++ b/kevinos/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
     <title>KevinOS | Kevin Middleton</title>
-    <meta name="description" content="Kevin Middleton, Senior Product Manager (full-stack PM by practice). Portfolio reimagined as a retro OS. 12+ years building consumer, enterprise, and platform SaaS products.">
+    <meta name="description" content="Kevin Middleton, Full Stack Product Manager. A portfolio reimagined as a retro operating system. 12+ years across consumer, enterprise, and platform SaaS.">
     <link rel="canonical" href="https://middleton.io/kevinos/">
     <link rel="icon" href="https://middleton.io/kevinos/images/alien-monster.png">
     <link rel="apple-touch-icon" href="https://middleton.io/kevinos/images/alien-monster.png">
@@ -1050,7 +1050,7 @@
                             <span class="kos-feed-dot" aria-hidden="true"></span>
                             <span class="kos-feed-info">
                                 <span class="kos-feed-row-title">Product Management is dead. Long live Product Management.</span>
-                                <span class="kos-feed-excerpt">We keep killing product management. It keeps coming back.</span>
+                                <span class="kos-feed-excerpt">We keep killing product management. It keeps coming back. What the latest round of obituaries gets wrong about the work, and who actually does it.</span>
                                 <span class="kos-feed-date">Jul 23</span>
                             </span>
                         </a>

--- a/llms.txt
+++ b/llms.txt
@@ -29,7 +29,7 @@ Structured data on the site declares this person once, as
 
 <!-- BLOG:START -->
 - [Blog index](https://middleton.io/blog/): Essays on building with AI, product, and the systems in between.
-- [Product Management is dead. Long live Product Management.](https://middleton.io/blog/product-management-is-dead/): We keep killing product management. It keeps coming back.
+- [Product Management is dead. Long live Product Management.](https://middleton.io/blog/product-management-is-dead/): We keep killing product management. It keeps coming back. What the latest round of obituaries gets wrong about the work, and who actually does it.
 - [AI guilt is the new recycling](https://middleton.io/blog/ai-guilt-is-the-new-recycling/): AI guilt is everywhere, and it is landing on exhausted people instead of the leaders who earned it. We have done this before. Last time we called it recycling.
 - [It's almost always the resume](https://middleton.io/blog/its-almost-always-the-resume/): When a search stalls, people blame the ATS, the AI, the economy. Almost every time I look, it's the resume. So I overhauled my own. Here's exactly what changed and why.
 - [At work, curiosity can be the difference between thriving and surviving](https://middleton.io/blog/curiosity-makes-or-breaks/): You can usually tell within a few weeks whether you'll thrive at a company or just survive it. It comes down to what happens when you ask one simple question.

--- a/nyc/index.htm
+++ b/nyc/index.htm
@@ -5,7 +5,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Kevin Middleton — Full Stack Product Manager in NYC</title>
-  <meta name="description" content="Kevin Middleton is a full stack product manager in NYC with 12 years of experience at Oracle, Lever, Rocket Lawyer, and HVAC.com. Currently seeking a team that values ownership and direct collaboration.">
+  <meta name="description" content="Kevin Middleton, Full Stack Product Manager in NYC. 12 years at Oracle, Lever, Rocket Lawyer, and HVAC.com. Looking for a team that values ownership.">
   <meta name="author" content="Kevin Middleton">
   <meta name="robots" content="index, follow">
   <link rel="canonical" href="https://middleton.io/nyc/">

--- a/prototypes/cypress/index.html
+++ b/prototypes/cypress/index.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="robots" content="noindex, nofollow">
 <title>Cypress — Exercise Access</title>
+    <meta name="description" content="A private exercise: the point of view and the crash-course deck behind it. Password required.">
 <!-- Privacy-friendly analytics by Plausible -->
 <script async src="https://plausible.io/js/pa-CycHtdoRKtjDMtDpjBTA4.js"></script>
 <script>

--- a/prototypes/ww/index.html
+++ b/prototypes/ww/index.html
@@ -5,6 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="robots" content="noindex, nofollow">
 <title>WeightWatchers — Prototype Access</title>
+    <meta name="description" content="Private prototype: site improvement concepts for WeightWatchers. Password required.">
 <!-- Privacy-friendly analytics by Plausible -->
 <script async src="https://plausible.io/js/pa-CycHtdoRKtjDMtDpjBTA4.js"></script>
 <script>

--- a/slides/success-academy/index.html
+++ b/slides/success-academy/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Success Academy: PM for Family Apps and Public Web · Slides I Made for Free</title>
 
-<meta name="description" content="Five rounds for a Product Manager role at Success Academy. Prototype, onsite panel, final with the CTO. Did not advance. Here's the work and the feedback exchange." />
+<meta name="description" content="Five rounds for a PM role at Success Academy. Prototype, onsite panel, final with the CTO. Did not advance. Here's the work and the feedback exchange." />
 <meta name="author" content="Kevin Middleton" />
 <link rel="canonical" href="https://middleton.io/slides/success-academy/" />
 


### PR DESCRIPTION
Seven pages trimmed under the ~160 character truncation point, two password-gated prototypes given descriptions they lacked, and one blog excerpt lengthened.

| Page | Was | Now |
|---|---|---|
| `/` | 165 | 141 |
| `/kevinos/` | 173 | 154 |
| `/nyc/` | 202 | 149 |
| `/kevin/` | 254 | 141 |
| `/slides/success-academy/` | 163 | 150 |
| `/blog/product-management-is-dead/` | 57 | 146 |
| `/prototypes/cypress/` | none | 93 |
| `/prototypes/ww/` | none | 83 |

`/kevinos/` also carried the last "Senior Product Manager (full-stack PM by practice)" on the site. It now reads Full Stack Product Manager like everywhere else — worth more than the length fix.

The blog change goes through `blog/_posts/*.md`, since `post.excerpt` is the single source for the meta description, og/twitter descriptions, JSON-LD, the card blurb on `/blog/`, the RSS item, the `llms.txt` entry and the KevinOS feed. One edit, eight surfaces. Generator verified idempotent.

**Deliberately not changed:** four blog excerpts still run 164–187. They lose only a few trailing words in search, and shortening them would also shorten the visible cards on the blog index and in RSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)