### PR TITLE
SEO: bring titles under the truncation point

### DIFF
--- a/blog/ai-guilt-is-the-new-recycling/index.html
+++ b/blog/ai-guilt-is-the-new-recycling/index.html
@@ -5,7 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#F4F4F5" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0F0F12" media="(prefers-color-scheme: dark)">
-    <title>AI guilt is the new recycling | Kevin Middleton</title>
+    <!-- No " | Kevin Middleton" suffix: it cost 18 chars of a ~60 char budget and
+         pushed real titles past the truncation point. og:title, twitter:title, the
+         h1, the blog card and the RSS item all use post.title directly, so nothing
+         visible changes. -->
+    <title>AI guilt is the new recycling</title>
     <meta name="description" content="AI guilt is everywhere, and it is landing on exhausted people instead of the leaders who earned it. We have done this before. Last time we called it recycling.">
 
     <link rel="canonical" href="https://middleton.io/blog/ai-guilt-is-the-new-recycling/">

--- a/blog/ai-is-researching-you/index.html
+++ b/blog/ai-is-researching-you/index.html
@@ -5,7 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#F4F4F5" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0F0F12" media="(prefers-color-scheme: dark)">
-    <title>AI is researching you. Make sure it gets your story right. | Kevin Middleton</title>
+    <!-- No " | Kevin Middleton" suffix: it cost 18 chars of a ~60 char budget and
+         pushed real titles past the truncation point. og:title, twitter:title, the
+         h1, the blog card and the RSS item all use post.title directly, so nothing
+         visible changes. -->
+    <title>AI is researching you. Make sure it gets your story right.</title>
     <meta name="description" content="ChatGPT showed up in my site's referrer logs. Companies are worrying about how they appear in AI search. The same logic applies to many of us.">
 
     <link rel="canonical" href="https://middleton.io/blog/ai-is-researching-you/">

--- a/blog/ai-job-scanner-daily/index.html
+++ b/blog/ai-job-scanner-daily/index.html
@@ -5,7 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#F4F4F5" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0F0F12" media="(prefers-color-scheme: dark)">
-    <title>What Running an AI Job Scanner Daily Actually Looks Like | Kevin Middleton</title>
+    <!-- No " | Kevin Middleton" suffix: it cost 18 chars of a ~60 char budget and
+         pushed real titles past the truncation point. og:title, twitter:title, the
+         h1, the blog card and the RSS item all use post.title directly, so nothing
+         visible changes. -->
+    <title>What Running an AI Job Scanner Daily Actually Looks Like</title>
     <meta name="description" content="Two weeks running my AI job scanner. The field report: extraction failures, a temporary block, duplicate noise, and what actually held up.">
 
     <link rel="canonical" href="https://middleton.io/blog/ai-job-scanner-daily/">

--- a/blog/ai-job-search-assistant/index.html
+++ b/blog/ai-job-search-assistant/index.html
@@ -5,7 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#F4F4F5" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0F0F12" media="(prefers-color-scheme: dark)">
-    <title>I Built an AI Job Search Assistant That Texts Me When It Finds Roles I Should Apply To | Kevin Middleton</title>
+    <!-- No " | Kevin Middleton" suffix: it cost 18 chars of a ~60 char budget and
+         pushed real titles past the truncation point. og:title, twitter:title, the
+         h1, the blog card and the RSS item all use post.title directly, so nothing
+         visible changes. -->
+    <title>I Built an AI Job Search Assistant That Texts Me When It Finds Roles I Should Apply To</title>
     <meta name="description" content="How a Mac Mini in my apartment scans LinkedIn twice a day, filters for roles that match my profile, and texts me the results, for about six cents a day.">
 
     <link rel="canonical" href="https://middleton.io/blog/ai-job-search-assistant/">

--- a/blog/ai-tools-non-technical/index.html
+++ b/blog/ai-tools-non-technical/index.html
@@ -5,7 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#F4F4F5" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0F0F12" media="(prefers-color-scheme: dark)">
-    <title>We're not building great AI tools for non-technical audiences (yet) | Kevin Middleton</title>
+    <!-- No " | Kevin Middleton" suffix: it cost 18 chars of a ~60 char budget and
+         pushed real titles past the truncation point. og:title, twitter:title, the
+         h1, the blog card and the RSS item all use post.title directly, so nothing
+         visible changes. -->
+    <title>We're not building great AI tools for non-technical audiences (yet)</title>
     <meta name="description" content="I built a job scanner that runs while I sleep. I couldn't hand it to a smart, motivated friend. The gap between 'I want that' and 'I can do that' is still enormous.">
 
     <link rel="canonical" href="https://middleton.io/blog/ai-tools-non-technical/">

--- a/blog/applying-for-jobs-is-like-stand-up-comedy/index.html
+++ b/blog/applying-for-jobs-is-like-stand-up-comedy/index.html
@@ -5,7 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#F4F4F5" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0F0F12" media="(prefers-color-scheme: dark)">
-    <title>Applying for jobs is like stand-up comedy | Kevin Middleton</title>
+    <!-- No " | Kevin Middleton" suffix: it cost 18 chars of a ~60 char budget and
+         pushed real titles past the truncation point. og:title, twitter:title, the
+         h1, the blog card and the RSS item all use post.title directly, so nothing
+         visible changes. -->
+    <title>Applying for jobs is like stand-up comedy</title>
     <meta name="description" content="A lot of the standard job search advice is bunk, and the rest is easier to follow if you treat the whole thing like an open mic. Go up rusty, test your material, learn to handle hecklers.">
 
     <link rel="canonical" href="https://middleton.io/blog/applying-for-jobs-is-like-stand-up-comedy/">

--- a/blog/build-with-claude/index.html
+++ b/blog/build-with-claude/index.html
@@ -5,7 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#F4F4F5" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0F0F12" media="(prefers-color-scheme: dark)">
-    <title>I build web apps from my phone. Here's the whole setup. | Kevin Middleton</title>
+    <!-- No " | Kevin Middleton" suffix: it cost 18 chars of a ~60 char budget and
+         pushed real titles past the truncation point. og:title, twitter:title, the
+         h1, the blog card and the RSS item all use post.title directly, so nothing
+         visible changes. -->
+    <title>I build web apps from my phone. Here's the whole setup.</title>
     <meta name="description" content="No code, no IDE, just a Telegram message. A Mac at home runs Claude Code, and a free guide gets you the same setup.">
 
     <link rel="canonical" href="https://middleton.io/blog/build-with-claude/">

--- a/blog/curiosity-makes-or-breaks/index.html
+++ b/blog/curiosity-makes-or-breaks/index.html
@@ -5,7 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#F4F4F5" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0F0F12" media="(prefers-color-scheme: dark)">
-    <title>At work, curiosity can be the difference between thriving and surviving | Kevin Middleton</title>
+    <!-- No " | Kevin Middleton" suffix: it cost 18 chars of a ~60 char budget and
+         pushed real titles past the truncation point. og:title, twitter:title, the
+         h1, the blog card and the RSS item all use post.title directly, so nothing
+         visible changes. -->
+    <title>At work, curiosity can be the difference between thriving and surviving</title>
     <meta name="description" content="You can usually tell within a few weeks whether you'll thrive at a company or just survive it. It comes down to what happens when you ask one simple question.">
 
     <link rel="canonical" href="https://middleton.io/blog/curiosity-makes-or-breaks/">

--- a/blog/everyone-can-build-now/index.html
+++ b/blog/everyone-can-build-now/index.html
@@ -5,7 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#F4F4F5" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0F0F12" media="(prefers-color-scheme: dark)">
-    <title>Everyone can build now. The fundamentals shouldn't change. | Kevin Middleton</title>
+    <!-- No " | Kevin Middleton" suffix: it cost 18 chars of a ~60 char budget and
+         pushed real titles past the truncation point. og:title, twitter:title, the
+         h1, the blog card and the RSS item all use post.title directly, so nothing
+         visible changes. -->
+    <title>Everyone can build now. The fundamentals shouldn't change.</title>
     <meta name="description" content="AI made everyone a builder. It didn't say who orchestrates them, or who validates and integrates all the prototypes.">
 
     <link rel="canonical" href="https://middleton.io/blog/everyone-can-build-now/">

--- a/blog/its-almost-always-the-resume/index.html
+++ b/blog/its-almost-always-the-resume/index.html
@@ -5,7 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#F4F4F5" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0F0F12" media="(prefers-color-scheme: dark)">
-    <title>It's almost always the resume | Kevin Middleton</title>
+    <!-- No " | Kevin Middleton" suffix: it cost 18 chars of a ~60 char budget and
+         pushed real titles past the truncation point. og:title, twitter:title, the
+         h1, the blog card and the RSS item all use post.title directly, so nothing
+         visible changes. -->
+    <title>It's almost always the resume</title>
     <meta name="description" content="When a search stalls, people blame the ATS, the AI, the economy. Almost every time I look, it's the resume. So I overhauled my own. Here's exactly what changed and why.">
 
     <link rel="canonical" href="https://middleton.io/blog/its-almost-always-the-resume/">

--- a/blog/job-search-agent/index.html
+++ b/blog/job-search-agent/index.html
@@ -5,7 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#F4F4F5" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0F0F12" media="(prefers-color-scheme: dark)">
-    <title>Need an AI recruiter that works for you? Try this one. | Kevin Middleton</title>
+    <!-- No " | Kevin Middleton" suffix: it cost 18 chars of a ~60 char budget and
+         pushed real titles past the truncation point. og:title, twitter:title, the
+         h1, the blog card and the RSS item all use post.title directly, so nothing
+         visible changes. -->
+    <title>Need an AI recruiter that works for you? Try this one.</title>
     <meta name="description" content="Open-sourced a Claude Code plugin that turns Claude into your job search assistant. The accessible version of the system I built for myself, free on GitHub.">
 
     <link rel="canonical" href="https://middleton.io/blog/job-search-agent/">

--- a/blog/one-page-you-own/index.html
+++ b/blog/one-page-you-own/index.html
@@ -5,7 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#F4F4F5" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0F0F12" media="(prefers-color-scheme: dark)">
-    <title>You should have a website. And you can build it in an hour with Claude. | Kevin Middleton</title>
+    <!-- No " | Kevin Middleton" suffix: it cost 18 chars of a ~60 char budget and
+         pushed real titles past the truncation point. og:title, twitter:title, the
+         h1, the blog card and the RSS item all use post.title directly, so nothing
+         visible changes. -->
+    <title>You should have a website. And you can build it in an hour with Claude.</title>
     <meta name="description" content="An old colleague got laid off, shipped a personal site ten days after I sent him a starter kit, and took back his story online. So I turned the starter into a free plugin.">
 
     <link rel="canonical" href="https://middleton.io/blog/one-page-you-own/">

--- a/blog/owning-your-context/index.html
+++ b/blog/owning-your-context/index.html
@@ -5,7 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#F4F4F5" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0F0F12" media="(prefers-color-scheme: dark)">
-    <title>I Paid to Scrub My Data From Hundreds of Data Brokers. Then I Sent Even More to an AI. | Kevin Middleton</title>
+    <!-- No " | Kevin Middleton" suffix: it cost 18 chars of a ~60 char budget and
+         pushed real titles past the truncation point. og:title, twitter:title, the
+         h1, the blog card and the RSS item all use post.title directly, so nothing
+         visible changes. -->
+    <title>I Paid to Scrub My Data From Hundreds of Data Brokers. Then I Sent Even More to an AI.</title>
     <meta name="description" content="I pay a service to scrub my data from hundreds of brokers. Then I hand an AI my taxes, my finances, my fears. Where should that personal context actually live?">
 
     <link rel="canonical" href="https://middleton.io/blog/owning-your-context/">

--- a/blog/product-management-is-dead/index.html
+++ b/blog/product-management-is-dead/index.html
@@ -5,7 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#F4F4F5" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0F0F12" media="(prefers-color-scheme: dark)">
-    <title>Product Management is dead. Long live Product Management. | Kevin Middleton</title>
+    <!-- No " | Kevin Middleton" suffix: it cost 18 chars of a ~60 char budget and
+         pushed real titles past the truncation point. og:title, twitter:title, the
+         h1, the blog card and the RSS item all use post.title directly, so nothing
+         visible changes. -->
+    <title>Product Management is dead. Long live Product Management.</title>
     <meta name="description" content="We keep killing product management. It keeps coming back. What the latest round of obituaries gets wrong about the work, and who actually does it.">
 
     <link rel="canonical" href="https://middleton.io/blog/product-management-is-dead/">

--- a/blog/twice-a-day/index.html
+++ b/blog/twice-a-day/index.html
@@ -5,7 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#F4F4F5" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0F0F12" media="(prefers-color-scheme: dark)">
-    <title>How to Digitally Detox Right Now (Even If You're Job Searching) | Kevin Middleton</title>
+    <!-- No " | Kevin Middleton" suffix: it cost 18 chars of a ~60 char budget and
+         pushed real titles past the truncation point. og:title, twitter:title, the
+         h1, the blog card and the RSS item all use post.title directly, so nothing
+         visible changes. -->
+    <title>How to Digitally Detox Right Now (Even If You're Job Searching)</title>
     <meta name="description" content="I check my inbox twice a day. Here's what a morning briefing from my AI assistant gave me back in a brutal job market.">
 
     <link rel="canonical" href="https://middleton.io/blog/twice-a-day/">

--- a/index.htm
+++ b/index.htm
@@ -7,7 +7,7 @@
      real dark mode, so the browser chrome should follow it. -->
 <meta name="theme-color" content="#F4F4F5" media="(prefers-color-scheme: light)">
 <meta name="theme-color" content="#0F0F12" media="(prefers-color-scheme: dark)">
-<title>Kevin Middleton - Full Stack Product Manager | Platforms, Internal Tools &amp; AI Workflows</title>
+<title>Kevin Middleton - Full Stack Product Manager</title>
 <!-- descriptions lead with "Full Stack Product Manager" rather than the live
      site's "Senior Product Manager and full-stack PM", to match the identity
      the rest of this build standardised on (title, header, hero arc line). -->

--- a/prototypes/amex/index.html
+++ b/prototypes/amex/index.html
@@ -4,7 +4,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Resy × AI Agents: From Customer Journey to MCP Server | Kevin Middleton</title>
+<title>Resy × AI Agents: From Customer Journey to MCP Server</title>
 <meta name="description" content="Resy x AI Agents: A prototype exploring how MCP servers can power AI-driven dining experiences at American Express.">
 <link rel="canonical" href="https://middleton.io/prototypes/amex/">
 <meta property="og:type" content="website">

--- a/slides/amex/index.html
+++ b/slides/amex/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>American Express: Agentic MCP Prototype · Slides I Made for Free</title>
+<title>American Express: Agentic MCP Prototype · Slides</title>
 
 <meta name="description" content="Three rounds for an Amex Digital Labs PM role. I built a live prototype between rounds. The role got paused. Here's the work." />
 <meta name="author" content="Kevin Middleton" />

--- a/slides/applause/index.html
+++ b/slides/applause/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Applause: When the Interview Is Just Free Consulting · Slides I Made for Free</title>
+<title>Applause: When the Interview Is Just Free Consulting · Slides</title>
 
 <meta name="description" content="A 45-minute interview that turned into a live strategy session on the company's real product. I gave the work. They ghosted. A cautionary tale." />
 <meta name="author" content="Kevin Middleton" />

--- a/slides/gong/index.html
+++ b/slides/gong/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Gong: WhatsApp vs. Slack Connect Panel · Slides I Made for Free</title>
+<title>Gong: WhatsApp vs. Slack Connect Panel · Slides</title>
 
 <meta name="description" content="Real panel exercise for Gong's Senior PM, International & Enterprise role. Prompt, research, the actual decks, and what I'd change." />
 <meta name="author" content="Kevin Middleton" />

--- a/slides/hvac/index.html
+++ b/slides/hvac/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>HVAC.com: The Take-Home That Got the Yes · Slides I Made for Free</title>
+<title>HVAC.com: The Take-Home That Got the Yes · Slides</title>
 
 <meta name="description" content="How I got the Senior PM role at HVAC.com. The take-home brief, five rounds, a full-day onsite, the offer pressure, and what I'd change next time." />
 <meta name="author" content="Kevin Middleton" />

--- a/slides/justworks/index.html
+++ b/slides/justworks/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Justworks: Wage Garnishment Case Study · Slides I Made for Free</title>
+<title>Justworks: Wage Garnishment Case Study · Slides</title>
 
 <meta name="description" content="Take-home case study and onsite workshop for Justworks Senior PM, PayTax. Centerpiece is a real user interview with a small business owner in Virginia." />
 <meta name="author" content="Kevin Middleton" />

--- a/slides/red-ventures/index.html
+++ b/slides/red-ventures/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Red Ventures: When "Hypothetical" Was a Live Marketplace · Slides I Made for Free</title>
+<title>Red Ventures: When "Hypothetical" Was a Live Marketplace · Slides</title>
 
 <meta name="description" content="A take-home for a Red Ventures PM role. The 'hypothetical' case was one of their actual brands. I sent the work, then asked them not to use it." />
 <meta name="author" content="Kevin Middleton" />

--- a/slides/success-academy/index.html
+++ b/slides/success-academy/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Success Academy: PM for Family Apps and Public Web · Slides I Made for Free</title>
+<title>Success Academy: PM for Family Apps and Public Web · Slides</title>
 
 <meta name="description" content="Five rounds for a PM role at Success Academy. Prototype, onsite panel, final with the CTO. Did not advance. Here's the work and the feedback exchange." />
 <meta name="author" content="Kevin Middleton" />

--- a/tools/blog-generate.mjs
+++ b/tools/blog-generate.mjs
@@ -245,7 +245,11 @@ function articlePage(post, all) {
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#F4F4F5" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0F0F12" media="(prefers-color-scheme: dark)">
-    <title>${esc(post.title)} | Kevin Middleton</title>
+    <!-- No " | Kevin Middleton" suffix: it cost 18 chars of a ~60 char budget and
+         pushed real titles past the truncation point. og:title, twitter:title, the
+         h1, the blog card and the RSS item all use post.title directly, so nothing
+         visible changes. -->
+    <title>${esc(post.title)}</title>
     <meta name="description" content="${escAttr(post.excerpt)}">
 
     <link rel="canonical" href="${url}">


### PR DESCRIPTION
Three structural changes. **No visible copy is touched** — 21 pages were over ~60 characters, 10 remain, and each of those needs a headline rewrite rather than a structural fix.

**1. Blog posts drop the `| Kevin Middleton` suffix from `<title>`.** It cost 18 characters of a ~60 character budget. The `h1`, blog card, RSS item, `og:title` and `twitter:title` all use `post.title` directly, so nothing a reader sees changes. Fixes 6 posts.

**2. Slide decks shorten `· Slides I Made for Free` to `· Slides`.** Fixes 5 of 7.

**3. Homepage title: 87 → 43.** `Kevin Middleton - Full Stack Product Manager`. Everything after "Manager" was being cut anyway, and those keywords live in the description and `h1`. Hyphen kept rather than an em dash, per house style.

Plus `prototypes/amex`, which carried the same brand suffix while over the limit.

Generator verified idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)