### PR TITLE
Nav: move the two-row breakpoint from 900px to 1100px

### DIFF
--- a/blog/ai-guilt-is-the-new-recycling/index.html
+++ b/blog/ai-guilt-is-the-new-recycling/index.html
@@ -33,7 +33,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/ai-is-researching-you/index.html
+++ b/blog/ai-is-researching-you/index.html
@@ -33,7 +33,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/ai-job-scanner-daily/index.html
+++ b/blog/ai-job-scanner-daily/index.html
@@ -33,7 +33,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/ai-job-search-assistant/index.html
+++ b/blog/ai-job-search-assistant/index.html
@@ -33,7 +33,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/ai-tools-non-technical/index.html
+++ b/blog/ai-tools-non-technical/index.html
@@ -33,7 +33,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/applying-for-jobs-is-like-stand-up-comedy/index.html
+++ b/blog/applying-for-jobs-is-like-stand-up-comedy/index.html
@@ -33,7 +33,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/build-with-claude/index.html
+++ b/blog/build-with-claude/index.html
@@ -33,7 +33,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/curiosity-makes-or-breaks/index.html
+++ b/blog/curiosity-makes-or-breaks/index.html
@@ -33,7 +33,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/everyone-can-build-now/index.html
+++ b/blog/everyone-can-build-now/index.html
@@ -33,7 +33,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/index.html
+++ b/blog/index.html
@@ -27,7 +27,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/its-almost-always-the-resume/index.html
+++ b/blog/its-almost-always-the-resume/index.html
@@ -33,7 +33,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/job-search-agent/index.html
+++ b/blog/job-search-agent/index.html
@@ -33,7 +33,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/one-page-you-own/index.html
+++ b/blog/one-page-you-own/index.html
@@ -33,7 +33,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/owning-your-context/index.html
+++ b/blog/owning-your-context/index.html
@@ -33,7 +33,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/product-management-is-dead/index.html
+++ b/blog/product-management-is-dead/index.html
@@ -33,7 +33,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/blog/twice-a-day/index.html
+++ b/blog/twice-a-day/index.html
@@ -33,7 +33,7 @@
 
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/casestudies/case-study-hvac.html
+++ b/casestudies/case-study-hvac.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Turning Traffic Into Intent: Calculators & Conversion at HVAC.com">
     <meta name="twitter:description" content="Built high-intent calculators that converted at 50x the site baseline.">
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
 {

--- a/casestudies/case-study-lever.html
+++ b/casestudies/case-study-lever.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Moving Lever Upmarket: Bulk Import & HRIS Sync">
     <meta name="twitter:description" content="How we proved Lever could operate at enterprise scale.">
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
 {

--- a/casestudies/case-study-oracle.html
+++ b/casestudies/case-study-oracle.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Scaling Social: Platform Overhaul & Network Expansion at Oracle">
     <meta name="twitter:description" content="Led a year-long platform modernization, doubling social network coverage.">
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
 {

--- a/casestudies/case-study-rocketlawyer-covea.html
+++ b/casestudies/case-study-rocketlawyer-covea.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Co-Branded Partner Sites at Rocket Lawyer">
     <meta name="twitter:description" content="How we launched Rocket Lawyer's first enterprise partnership.">
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
 {

--- a/casestudies/case-study-rocketlawyer-mobile.html
+++ b/casestudies/case-study-rocketlawyer-mobile.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Mobile Conversion Optimization at Rocket Lawyer">
     <meta name="twitter:description" content="Drove a 5% conversion lift through targeted A/B testing on mobile.">
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
 {

--- a/casestudies/case-study-sendoso.html
+++ b/casestudies/case-study-sendoso.html
@@ -20,7 +20,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="eGift Platform Expansion & Square Partnership at Sendoso">
     <meta name="twitter:description" content="Scaled catalog coverage and landed strategic partnerships at Sendoso.">
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
 {

--- a/casestudies/index.html
+++ b/casestudies/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#F4F4F5" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0F0F12" media="(prefers-color-scheme: dark)">
     <title>Case Studies | Kevin Middleton</title>
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <meta name="description"
         content="Selected product case studies from Kevin Middleton — conversion optimization, 0-to-1 products, enterprise partnerships, and platform modernization.">
     <link rel="icon" type="image/x-icon" href="https://middleton.io/favicon.ico">

--- a/fv.css
+++ b/fv.css
@@ -2569,7 +2569,10 @@ body.p-slides .verdict.bad .icon{color:var(--c2-text)}
    already solved this by wrapping to a second row; this makes that the shared
    behaviour so every page has the same nav. Row 1 is wordmark + Office Hours,
    row 2 is the full-width link rail, which scrolls if it needs to. */
-@media(max-width:900px){
+/* 1100, not 900. Measured: the gap between the wordmark and the link rail is
+   60px at 1150, 37px at 1100, 14px at 1050 and -9px at 1000, i.e. the subtitle
+   ran into "Building" anywhere below ~1050. Two rows now start before that. */
+@media(max-width:1100px){
   .nav{flex-wrap:wrap;row-gap:.55rem;align-items:center}
   .nav .mk{order:1}
   .nav .cta{order:2;margin-left:auto}
@@ -2632,7 +2635,7 @@ body.p-proto .card-head .card-k{min-width:0;line-height:1.25}
 /* The rail grows to fill the space between wordmark and CTA (that flex:1 is what
    stops it overflowing near 1000px), but its links were left-aligned inside it,
    so they hugged the wordmark and left a wide gap before Office Hours.  */
-@media(min-width:901px){
+@media(min-width:1101px){
   .nav-l{justify-content:center}
 }
 
@@ -2640,7 +2643,7 @@ body.p-proto .card-head .card-k{min-width:0;line-height:1.25}
    the links midway between the wordmark (283px) and the CTA (106px), which sits
    ~88px right of true centre. A three-column grid with equal side tracks makes
    the middle track the page centre regardless of how wide the flanks are. */
-@media(min-width:901px){
+@media(min-width:1101px){
   .nav{display:grid;grid-template-columns:minmax(0,1fr) auto minmax(0,1fr);
     align-items:center;gap:1rem}
   .nav .mk{justify-self:start;grid-column:1}
@@ -2811,7 +2814,7 @@ body.p-cases .cs-metric-label{
    flex-basis:100% is what drops the links to their own line, so this block
    needs wrap ON. A later rule forcing nowrap squeezed all three onto one line
    and clipped the links, which is the bug this comment exists to prevent. */
-@media(max-width:900px){.fv .nav{align-items:center;row-gap:.65rem;flex-wrap:wrap}.fv .mk{order:1}.fv .cta{order:2;margin-left:auto}.fv .nav-l{order:3;flex-basis:100%;gap:.9rem;overflow-x:auto;flex-wrap:nowrap;
+@media(max-width:1100px){.fv .nav{align-items:center;row-gap:.65rem;flex-wrap:wrap}.fv .mk{order:1}.fv .cta{order:2;margin-left:auto}.fv .nav-l{order:3;flex-basis:100%;gap:.9rem;overflow-x:auto;flex-wrap:nowrap;
     scrollbar-width:none;-ms-overflow-style:none}.fv .nav-l::-webkit-scrollbar{display:none}.fv .nav-l a{white-space:nowrap}
 }
 /* Six links at 390px overran the rail by ~28px, clipping the last one with no
@@ -2819,13 +2822,13 @@ body.p-cases .cs-metric-label{
 /* The rail grows to fill the space between wordmark and CTA (that flex:1 is what
    stops it overflowing near 1000px), but its links were left-aligned inside it,
    so they hugged the wordmark and left a wide gap before Office Hours.  */
-@media(min-width:901px){.fv .nav-l{justify-content:center}
+@media(min-width:1101px){.fv .nav-l{justify-content:center}
 }
 /* Centre the rail on the PAGE, not between its neighbours. space-between put
    the links midway between the wordmark (283px) and the CTA (106px), which sits
    ~88px right of true centre. A three-column grid with equal side tracks makes
    the middle track the page centre regardless of how wide the flanks are. */
-@media(min-width:901px){.fv .nav{display:grid;grid-template-columns:minmax(0,1fr) auto minmax(0,1fr);
+@media(min-width:1101px){.fv .nav{display:grid;grid-template-columns:minmax(0,1fr) auto minmax(0,1fr);
     align-items:center;gap:1rem}.fv .nav .mk{justify-self:start;grid-column:1}.fv .nav-l{justify-self:center;grid-column:2;flex:0 0 auto;min-width:0;max-width:100%}.fv .nav .cta{justify-self:end;grid-column:3}
 }
 @media(max-width:430px){.fv .nav-l{gap:.62rem}.fv .nav-l a{font-size:.74rem}

--- a/index.htm
+++ b/index.htm
@@ -104,7 +104,7 @@
 </head>
 <body>
 
-<link rel="stylesheet" href="/fv.css?v=b7966cd1">
+<link rel="stylesheet" href="/fv.css?v=3bb54490">
 
 <div class="fv">
 

--- a/prototypes/index.html
+++ b/prototypes/index.html
@@ -16,7 +16,7 @@
 <meta name="twitter:card" content="summary_large_image">
 <link rel="icon" type="image/x-icon" href="/favicon.ico">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="stylesheet" href="/fv.css?v=b7966cd1">
+<link rel="stylesheet" href="/fv.css?v=3bb54490">
 <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/recipes/index.html
+++ b/recipes/index.html
@@ -23,7 +23,7 @@
 
   <link rel="icon" href="https://middleton.io/recipes/images/chef-technologist.webp">
   <link rel="apple-touch-icon" href="https://middleton.io/recipes/images/chef-technologist.webp">
-  <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+  <link rel="stylesheet" href="/fv.css?v=3bb54490">
 <script async src="https://plausible.io/js/pa-CycHtdoRKtjDMtDpjBTA4.js"></script>
 <script>
   window.plausible = window.plausible || function () { (plausible.q = plausible.q || []).push(arguments) }, plausible.init = plausible.init || function (i) { plausible.o = i || {} };

--- a/slides/index.html
+++ b/slides/index.html
@@ -28,7 +28,7 @@
 
 
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🤑</text></svg>" />
-<link rel="stylesheet" href="/fv.css?v=b7966cd1">
+<link rel="stylesheet" href="/fv.css?v=3bb54490">
 
 <!-- Privacy-friendly analytics -->
 <script async src="https://plausible.io/js/pa-OjFchTSjmO38TDwmb0xU5.js"></script>

--- a/tools/blog-generate.mjs
+++ b/tools/blog-generate.mjs
@@ -164,7 +164,7 @@ function seriesCallouts(post, all) {
 // ---------- shared chrome ----------
 const HEAD_LINKS = `    <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
-    <link rel="stylesheet" href="/fv.css?v=b7966cd1">
+    <link rel="stylesheet" href="/fv.css?v=3bb54490">
     <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">


### PR DESCRIPTION
Between 901 and ~1050 the wordmark's subtitle ran into the first nav link, because the one-row grid was still in force at those widths.

Measured gap, wordmark right edge to link rail left edge:

| width | gap |
|---|---|
| 1150 | 60px |
| 1100 | 37px |
| 1050 | 14px |
| **1000** | **-9px (collision)** |

Collision starts just under 1050, so the two-row layout now begins at 1100 and one row survives only above it, where the gap is at least 37px.

Six nav breakpoints moved, three shared and three under `.fv`. The 900px breakpoints for bento, values, cases and the strengths spine are unrelated layout rules and were left alone.

Verified at 1150 / 1120 / 1101 / 1100 / 1050 / 1000 / 960: clean one row above 1100, two rows at and below with the rail flush to the wordmark's left edge, no collision anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)