### PR TITLE
Blog: stop code blocks re-wrapping differently per browser

### DIFF
--- a/blog/ai-guilt-is-the-new-recycling/index.html
+++ b/blog/ai-guilt-is-the-new-recycling/index.html
@@ -34,7 +34,7 @@
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
     <link rel="stylesheet" href="/fv.css?v=3bb54490">
-    <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
+    <link rel="stylesheet" href="/blog/blog.css?v=d428f456">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <!-- Identity verification. Same three profiles the homepage claims, so every

--- a/blog/ai-is-researching-you/index.html
+++ b/blog/ai-is-researching-you/index.html
@@ -34,7 +34,7 @@
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
     <link rel="stylesheet" href="/fv.css?v=3bb54490">
-    <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
+    <link rel="stylesheet" href="/blog/blog.css?v=d428f456">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <!-- Identity verification. Same three profiles the homepage claims, so every

--- a/blog/ai-job-scanner-daily/index.html
+++ b/blog/ai-job-scanner-daily/index.html
@@ -34,7 +34,7 @@
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
     <link rel="stylesheet" href="/fv.css?v=3bb54490">
-    <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
+    <link rel="stylesheet" href="/blog/blog.css?v=d428f456">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <!-- Identity verification. Same three profiles the homepage claims, so every

--- a/blog/ai-job-search-assistant/index.html
+++ b/blog/ai-job-search-assistant/index.html
@@ -34,7 +34,7 @@
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
     <link rel="stylesheet" href="/fv.css?v=3bb54490">
-    <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
+    <link rel="stylesheet" href="/blog/blog.css?v=d428f456">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <!-- Identity verification. Same three profiles the homepage claims, so every

--- a/blog/ai-tools-non-technical/index.html
+++ b/blog/ai-tools-non-technical/index.html
@@ -34,7 +34,7 @@
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
     <link rel="stylesheet" href="/fv.css?v=3bb54490">
-    <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
+    <link rel="stylesheet" href="/blog/blog.css?v=d428f456">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <!-- Identity verification. Same three profiles the homepage claims, so every

--- a/blog/applying-for-jobs-is-like-stand-up-comedy/index.html
+++ b/blog/applying-for-jobs-is-like-stand-up-comedy/index.html
@@ -34,7 +34,7 @@
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
     <link rel="stylesheet" href="/fv.css?v=3bb54490">
-    <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
+    <link rel="stylesheet" href="/blog/blog.css?v=d428f456">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <!-- Identity verification. Same three profiles the homepage claims, so every

--- a/blog/blog.css
+++ b/blog/blog.css
@@ -253,7 +253,13 @@ figcaption {
 .prompt-block {
     position: relative;
     font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-    font-size: 13.5px;
+    /* 12.5px, not 13.5. The prompts in these posts are hard-wrapped at 74-77
+       characters, and at 13.5px exactly 77 fit the column: zero headroom. The
+       font stack resolves to different metrics per browser, so Safari fit one
+       character fewer and every line lost its last word to a soft wrap, which
+       read as random short lines. 12.5px fits ~84, giving 7 characters of
+       slack so the authored line breaks survive any browser. */
+    font-size: 12.5px;
     line-height: 1.6;
     background: var(--card-bg);
     border: 1px solid var(--border);

--- a/blog/build-with-claude/index.html
+++ b/blog/build-with-claude/index.html
@@ -34,7 +34,7 @@
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
     <link rel="stylesheet" href="/fv.css?v=3bb54490">
-    <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
+    <link rel="stylesheet" href="/blog/blog.css?v=d428f456">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <!-- Identity verification. Same three profiles the homepage claims, so every

--- a/blog/building-personal-ai-tools-for-everyone-else/index.html
+++ b/blog/building-personal-ai-tools-for-everyone-else/index.html
@@ -34,7 +34,7 @@
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
     <link rel="stylesheet" href="/fv.css?v=3bb54490">
-    <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
+    <link rel="stylesheet" href="/blog/blog.css?v=d428f456">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <!-- Identity verification. Same three profiles the homepage claims, so every

--- a/blog/curiosity-makes-or-breaks/index.html
+++ b/blog/curiosity-makes-or-breaks/index.html
@@ -34,7 +34,7 @@
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
     <link rel="stylesheet" href="/fv.css?v=3bb54490">
-    <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
+    <link rel="stylesheet" href="/blog/blog.css?v=d428f456">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <!-- Identity verification. Same three profiles the homepage claims, so every

--- a/blog/everyone-can-build-now/index.html
+++ b/blog/everyone-can-build-now/index.html
@@ -34,7 +34,7 @@
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
     <link rel="stylesheet" href="/fv.css?v=3bb54490">
-    <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
+    <link rel="stylesheet" href="/blog/blog.css?v=d428f456">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <!-- Identity verification. Same three profiles the homepage claims, so every

--- a/blog/index.html
+++ b/blog/index.html
@@ -28,7 +28,7 @@
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
     <link rel="stylesheet" href="/fv.css?v=3bb54490">
-    <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
+    <link rel="stylesheet" href="/blog/blog.css?v=d428f456">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <!-- Identity verification. Same three profiles the homepage claims, so every

--- a/blog/its-almost-always-the-resume/index.html
+++ b/blog/its-almost-always-the-resume/index.html
@@ -34,7 +34,7 @@
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
     <link rel="stylesheet" href="/fv.css?v=3bb54490">
-    <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
+    <link rel="stylesheet" href="/blog/blog.css?v=d428f456">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <!-- Identity verification. Same three profiles the homepage claims, so every

--- a/blog/job-search-agent/index.html
+++ b/blog/job-search-agent/index.html
@@ -34,7 +34,7 @@
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
     <link rel="stylesheet" href="/fv.css?v=3bb54490">
-    <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
+    <link rel="stylesheet" href="/blog/blog.css?v=d428f456">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <!-- Identity verification. Same three profiles the homepage claims, so every

--- a/blog/one-page-you-own/index.html
+++ b/blog/one-page-you-own/index.html
@@ -34,7 +34,7 @@
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
     <link rel="stylesheet" href="/fv.css?v=3bb54490">
-    <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
+    <link rel="stylesheet" href="/blog/blog.css?v=d428f456">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <!-- Identity verification. Same three profiles the homepage claims, so every

--- a/blog/owning-your-context/index.html
+++ b/blog/owning-your-context/index.html
@@ -34,7 +34,7 @@
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
     <link rel="stylesheet" href="/fv.css?v=3bb54490">
-    <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
+    <link rel="stylesheet" href="/blog/blog.css?v=d428f456">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <!-- Identity verification. Same three profiles the homepage claims, so every

--- a/blog/product-management-is-dead/index.html
+++ b/blog/product-management-is-dead/index.html
@@ -34,7 +34,7 @@
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
     <link rel="stylesheet" href="/fv.css?v=3bb54490">
-    <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
+    <link rel="stylesheet" href="/blog/blog.css?v=d428f456">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <!-- Identity verification. Same three profiles the homepage claims, so every

--- a/blog/twice-a-day/index.html
+++ b/blog/twice-a-day/index.html
@@ -34,7 +34,7 @@
     <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
     <link rel="stylesheet" href="/fv.css?v=3bb54490">
-    <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
+    <link rel="stylesheet" href="/blog/blog.css?v=d428f456">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <!-- Identity verification. Same three profiles the homepage claims, so every

--- a/tools/blog-generate.mjs
+++ b/tools/blog-generate.mjs
@@ -165,7 +165,7 @@ function seriesCallouts(post, all) {
 const HEAD_LINKS = `    <!-- One stylesheet for the whole site. No webfont request: fv.css uses a
          system stack, which is also why the old Inter/Epilogue links are gone. -->
     <link rel="stylesheet" href="/fv.css?v=3bb54490">
-    <link rel="stylesheet" href="/blog/blog.css?v=99c23c60">
+    <link rel="stylesheet" href="/blog/blog.css?v=d428f456">
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <!-- Identity verification. Same three profiles the homepage claims, so every


### PR DESCRIPTION
The prompts in these posts are hard-wrapped in the markdown at **74–77 characters**. At `13.5px`, exactly **77** fit the column — zero headroom.

The font stack resolves to different metrics per browser. Safari fit one character fewer, so every authored line soft-wrapped and orphaned its last word: `duplicates`, `the` and `me` alone on their own lines in Safari but not Chrome.

`12.5px` fits ~84 characters, leaving 7 characters of slack so the authored line breaks survive whichever monospace font a browser picks.

Measured in Chrome before: 632px inner width, 8.13px per character, 77 characters, longest source line 77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)